### PR TITLE
Updated gtk4 to 0.2 and new declaration.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,7 @@ futures-core = "0.3"
 tokio = { version = "1.9", optional = true, features = ["rt"] }
 async-trait = { version = "0.1", optional = true}
 
-[dependencies.gtk]
-package = "gtk4"
-version = "0.1"
+gtk = {version="0.2", package="gtk4"}
 
 [features]
 default = []


### PR DESCRIPTION
The GTK4 has been updated to 0.2, and [apparently](https://gtk-rs.org/gtk4-rs/git/book/prerequisites.html#cargo) a new way of specifying the package.

I haven't encountered any issues when issuing `cargo build` but haven't tested it on any projects.