### PR TITLE
Remove classname methods from WidgetPlus

### DIFF
--- a/relm4-components/src/alert.rs
+++ b/relm4-components/src/alert.rs
@@ -3,7 +3,7 @@
 //! **[Example implementation](https://github.com/AaronErhardt/relm4/blob/main/relm4-examples/examples/alert.rs)**
 
 use gtk::prelude::{DialogExt, GtkWindowExt, WidgetExt};
-use relm4::{send, ComponentUpdate, Model, Sender, WidgetPlus};
+use relm4::{send, ComponentUpdate, Model, Sender};
 
 pub struct AlertSettings {
     /// Large text
@@ -133,7 +133,7 @@ where
             let accept_widget = dialog
                 .widget_for_response(gtk::ResponseType::Accept)
                 .expect("No button for accept response set");
-            accept_widget.add_class_name("destructive-action");
+            accept_widget.add_css_class("destructive-action");
         }
     }
 }

--- a/relm4-examples/examples/components.rs
+++ b/relm4-examples/examples/components.rs
@@ -1,7 +1,7 @@
 use gtk::prelude::{BoxExt, ButtonExt, DialogExt, GtkWindowExt, ToggleButtonExt, WidgetExt};
 use relm4::{
     send, AppUpdate, ComponentUpdate, Components, Model, RelmApp, RelmComponent, Sender,
-    WidgetPlus, Widgets,
+    Widgets,
 };
 
 enum HeaderMsg {
@@ -49,7 +49,7 @@ impl Widgets<HeaderModel, AppModel> for HeaderWidgets {
     view! {
         gtk::HeaderBar {
             set_title_widget = Some(&gtk::Box) {
-                add_class_name: "linked",
+                add_css_class: "linked",
                 append: group = &gtk::ToggleButton {
                     set_label: "View",
                     set_active: true,

--- a/relm4-examples/examples/macro_test.rs
+++ b/relm4-examples/examples/macro_test.rs
@@ -52,7 +52,7 @@ impl Widgets<AppModel, ()> for AppWidgets {
                     connect_clicked(sender) => move |_| {
                         send!(sender, AppMsg::Increment);
                     },
-                    add_class_name: iterate!(&model.classes),
+                    add_css_class: iterate!(&model.classes),
                 },
                 append = &gtk::Button::new() {
                     set_label: track!(false, "Decrement"),

--- a/src/util/widget_plus.rs
+++ b/src/util/widget_plus.rs
@@ -9,21 +9,9 @@ pub trait WidgetPlus {
     /// Set margin at start, end, top and bottom all at once.
     fn set_margin_all(&self, margin: i32);
 
-    /// Add class name to self that can be used inside CSS selectors.
-    fn add_class_name(&self, class: &str);
-
-    /// Remove class name from self.
-    fn remove_class_name(&self, class: &str);
-
     /// Add class name if active is [`true`] and
     /// remove class name if active is [`false`]
-    fn set_class_active(&self, class: &str, active: bool) {
-        if active {
-            self.add_class_name(class);
-        } else {
-            self.remove_class_name(class);
-        }
-    }
+    fn set_class_active(&self, class: &str, active: bool);
 
     /// Add inline CSS instructions to a widget.
     /// ```
@@ -42,12 +30,12 @@ impl<W: gtk::prelude::WidgetExt> WidgetPlus for W {
         self.set_margin_bottom(margin);
     }
 
-    fn add_class_name(&self, class: &str) {
-        self.style_context().add_class(class);
-    }
-
-    fn remove_class_name(&self, class: &str) {
-        self.style_context().remove_class(class);
+    fn set_class_active(&self, class: &str, active: bool) {
+        if active {
+            self.add_css_class(class);
+        } else {
+            self.remove_css_class(class);
+        }
     }
 
     fn inline_css(&self, style_data: &[u8]) {


### PR DESCRIPTION
There is already `WidgetExt::{add_css_class, remove_css_class}` in GTK4.