### PR TITLE
[WIP] Make reusing components in the same view is easier

### DIFF
--- a/relm4-components/src/alert.rs
+++ b/relm4-components/src/alert.rs
@@ -7,6 +7,7 @@ use relm4::{send, ComponentUpdate, Model, Sender};
 
 use crate::ParentWindow;
 
+#[derive(Clone)]
 /// Configuration for the alert dialog component
 pub struct AlertSettings {
     /// Large text
@@ -43,6 +44,7 @@ impl Model for AlertModel {
     type Msg = AlertMsg;
     type Widgets = AlertWidgets;
     type Components = ();
+    type Settings = AlertSettings;
 }
 
 /// Interface for the parent model
@@ -50,9 +52,6 @@ pub trait AlertParent: Model
 where
     Self::Widgets: ParentWindow,
 {
-    /// Configuration for alert component.
-    fn alert_config(&self) -> AlertSettings;
-
     /// Message sent to parent if user clicks confirm button
     fn confirm_msg() -> Self::Msg;
 
@@ -68,9 +67,9 @@ where
     ParentModel: AlertParent,
     ParentModel::Widgets: ParentWindow,
 {
-    fn init_model(parent_model: &ParentModel) -> Self {
+    fn init_model(_parent_model: &ParentModel, settings: &AlertSettings) -> Self {
         AlertModel {
-            settings: parent_model.alert_config(),
+            settings: settings.clone(),
             is_active: false,
         }
     }

--- a/relm4-components/src/open_button/mod.rs
+++ b/relm4-components/src/open_button/mod.rs
@@ -31,7 +31,7 @@ pub struct OpenButtonModel {
     reset_popover: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug,Clone)]
 /// Configuration for the open button component
 pub struct OpenButtonSettings {
     /// Text of the open button.
@@ -42,6 +42,9 @@ pub struct OpenButtonSettings {
     /// Maximum amount of recent files to store.
     /// This is only used if a path for storing the recently opened files was set.
     pub max_recent_files: usize,
+
+    /// Settings for dialog window
+    pub dialog: OpenDialogSettings
 }
 
 #[doc(hidden)]
@@ -57,6 +60,7 @@ impl Model for OpenButtonModel {
     type Msg = OpenButtonMsg;
     type Widgets = OpenButtonWidgets;
     type Components = OpenButtonComponents;
+    type Settings = OpenButtonSettings;
 }
 
 /// Interface for the parent model of the open button component
@@ -64,8 +68,6 @@ pub trait OpenButtonParent: Model
 where
     Self::Widgets: ParentWindow,
 {
-    /// Returns a configuration for the open dialog.
-    fn dialog_config(&self) -> OpenDialogSettings;
     /// Returns a configuration for the open button.
     fn open_button_config(&self) -> OpenButtonSettings;
 
@@ -79,10 +81,10 @@ where
     ParentModel: Model + OpenButtonParent,
     ParentModel::Widgets: ParentWindow,
 {
-    fn init_model(parent_model: &ParentModel) -> Self {
+    fn init_model(_parent_model: &ParentModel, settings: &OpenButtonSettings) -> Self {
         OpenButtonModel {
-            config: parent_model.open_button_config(),
-            dialog_config: parent_model.dialog_config(),
+            config: settings.clone(),
+            dialog_config: settings.dialog.clone(),
             recent_files: None,
             initialized: false,
             reset_popover: false,
@@ -199,9 +201,10 @@ impl Components<OpenButtonModel> for OpenButtonComponents {
         parent_model: &OpenButtonModel,
         parent_widget: &OpenButtonWidgets,
         parent_sender: relm4::Sender<OpenButtonMsg>,
+        settings: &OpenButtonSettings,
     ) -> Self {
         OpenButtonComponents {
-            dialog: RelmComponent::new(parent_model, parent_widget, parent_sender),
+            dialog: RelmComponent::new(parent_model, parent_widget, parent_sender, &settings.dialog),
         }
     }
 }

--- a/relm4-components/src/open_dialog.rs
+++ b/relm4-components/src/open_dialog.rs
@@ -47,6 +47,7 @@ impl Model for OpenDialogModel {
     type Msg = OpenDialogMsg;
     type Widgets = OpenDialogWidgets;
     type Components = ();
+    type Settings = OpenDialogSettings;
 }
 
 /// Interface for the parent model
@@ -66,7 +67,7 @@ where
     ParentModel: OpenDialogParent,
     <ParentModel as relm4::Model>::Widgets: ParentWindow,
 {
-    fn init_model(parent_model: &ParentModel) -> Self {
+    fn init_model(parent_model: &ParentModel, _settings: &Self::Settings) -> Self {
         OpenDialogModel {
             settings: parent_model.dialog_config(),
             is_active: false,

--- a/relm4-components/src/save_dialog.rs
+++ b/relm4-components/src/save_dialog.rs
@@ -54,6 +54,7 @@ impl Model for SaveDialogModel {
     type Msg = SaveDialogMsg;
     type Widgets = SaveDialogWidgets;
     type Components = ();
+    type Settings = SaveDialogSettings;
 }
 
 /// Interface for the parent model of the save dialog
@@ -73,7 +74,7 @@ where
     ParentModel: SaveDialogParent,
     <ParentModel as relm4::Model>::Widgets: ParentWindow,
 {
-    fn init_model(parent_model: &ParentModel) -> Self {
+    fn init_model(parent_model: &ParentModel, _settings: &Self::Settings) -> Self {
         SaveDialogModel {
             settings: parent_model.dialog_config(),
             is_active: false,

--- a/relm4-examples/examples/alert.rs
+++ b/relm4-examples/examples/alert.rs
@@ -23,6 +23,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = AppComponents;
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -55,18 +56,6 @@ impl AppUpdate for AppModel {
 }
 
 impl AlertParent for AppModel {
-    fn alert_config(&self) -> AlertSettings {
-        AlertSettings {
-            text: "Do you want to quit without saving?",
-            secondary_text: Some("Your counter hasn't reached 42 yet"),
-            confirm_label: "Close without saving",
-            cancel_label: "Cancel",
-            option_label: Some("Save"),
-            is_modal: true,
-            destructive_accept: true,
-        }
-    }
-
     fn confirm_msg() -> Self::Msg {
         AppMsg::Close
     }
@@ -95,9 +84,20 @@ impl Components<AppModel> for AppComponents {
         model: &AppModel,
         parent_widgets: &AppWidgets,
         sender: Sender<AppMsg>,
+        _settings: &(),
     ) -> Self {
+        let dialog_settings = AlertSettings {
+            text: "Do you want to quit without saving?",
+            secondary_text: Some("Your counter hasn't reached 42 yet"),
+            confirm_label: "Close without saving",
+            cancel_label: "Cancel",
+            option_label: Some("Save"),
+            is_modal: true,
+            destructive_accept: true,
+        };
+
         AppComponents {
-            dialog: RelmComponent::new(model, parent_widgets, sender),
+            dialog: RelmComponent::new(model, parent_widgets, sender, &dialog_settings),
         }
     }
 }
@@ -147,6 +147,6 @@ impl Widgets<AppModel, ()> for AppWidgets {
 
 fn main() {
     let model = AppModel::default();
-    let app = RelmApp::new(model);
+    let app = RelmApp::new(model, &());
     app.run();
 }

--- a/relm4-examples/examples/components.rs
+++ b/relm4-examples/examples/components.rs
@@ -15,10 +15,11 @@ impl Model for HeaderModel {
     type Msg = HeaderMsg;
     type Widgets = HeaderWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl ComponentUpdate<AppModel> for HeaderModel {
-    fn init_model(_parent_model: &AppModel) -> Self {
+    fn init_model(_parent_model: &AppModel, _settings: &()) -> Self {
         HeaderModel {}
     }
 
@@ -95,10 +96,11 @@ impl Model for DialogModel {
     type Msg = DialogMsg;
     type Widgets = DialogWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl ComponentUpdate<AppModel> for DialogModel {
-    fn init_model(_parent_model: &AppModel) -> Self {
+    fn init_model(_parent_model: &AppModel, _settings: &()) -> Self {
         DialogModel { hidden: true }
     }
 
@@ -152,10 +154,11 @@ impl Components<AppModel> for AppComponents {
         parent_model: &AppModel,
         parent_widgets: &AppWidgets,
         parent_sender: Sender<AppMsg>,
+        _settings: &(),
     ) -> Self {
         AppComponents {
-            header: RelmComponent::new(parent_model, parent_widgets, parent_sender.clone()),
-            dialog: RelmComponent::new(parent_model, parent_widgets, parent_sender),
+            header: RelmComponent::new(parent_model, parent_widgets, parent_sender.clone(), &()),
+            dialog: RelmComponent::new(parent_model, parent_widgets, parent_sender, &()),
         }
     }
 }
@@ -181,6 +184,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = AppComponents;
+    type Settings = ();
 }
 
 #[relm4_macros::widget]
@@ -222,6 +226,6 @@ fn main() {
     let model = AppModel {
         mode: AppMode::View,
     };
-    let relm = RelmApp::new(model);
+    let relm = RelmApp::new(model, &());
     relm.run();
 }

--- a/relm4-examples/examples/components_old.rs
+++ b/relm4-examples/examples/components_old.rs
@@ -23,12 +23,14 @@ impl Model for Comp1Model {
     type Msg = CompMsg;
     type Widgets = Comp1Widgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl Model for Comp2Model {
     type Msg = CompMsg;
     type Widgets = Comp2Widgets;
     type Components = ();
+    type Settings = ();
 }
 
 #[derive(PartialEq)]
@@ -89,7 +91,7 @@ impl Widgets<Comp2Model, AppModel> for Comp2Widgets {
 }
 
 impl ComponentUpdate<AppModel> for Comp1Model {
-    fn init_model(_parent_model: &AppModel) -> Self {
+    fn init_model(_parent_model: &AppModel, _parent_settings: &()) -> Self {
         Comp1Model { hidden: false }
     }
 
@@ -114,7 +116,7 @@ impl ComponentUpdate<AppModel> for Comp1Model {
 }
 
 impl ComponentUpdate<AppModel> for Comp2Model {
-    fn init_model(_parent_model: &AppModel) -> Self {
+    fn init_model(_parent_model: &AppModel, _parent_settings: &()) -> Self {
         Comp2Model { hidden: true }
     }
 
@@ -147,14 +149,16 @@ impl Components<AppModel> for AppComponents {
         parent_model: &AppModel,
         parent_widgets: &AppWidgets,
         parent_sender: Sender<AppMsg>,
+        _parent_settings: &(),
     ) -> Self {
         AppComponents {
             comp1: RelmComponent::with_new_thread(
                 parent_model,
                 parent_widgets,
                 parent_sender.clone(),
+                &(),
             ),
-            comp2: RelmComponent::new(parent_model, parent_widgets, parent_sender),
+            comp2: RelmComponent::new(parent_model, parent_widgets, parent_sender, &()),
         }
     }
 }
@@ -180,6 +184,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = AppComponents;
+    type Settings = ();
 }
 
 impl Widgets<AppModel, ()> for AppWidgets {
@@ -250,6 +255,6 @@ impl AppUpdate for AppModel {
 
 fn main() {
     let model = AppModel { counter: 0 };
-    let relm = RelmApp::new(model);
+    let relm = RelmApp::new(model, &());
     relm.run();
 }

--- a/relm4-examples/examples/drawing.rs
+++ b/relm4-examples/examples/drawing.rs
@@ -22,6 +22,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -181,6 +182,6 @@ fn main() {
         points: Vec::new(),
         reset: false,
     };
-    let relm = RelmApp::new(model);
+    let relm = RelmApp::new(model, &());
     relm.run();
 }

--- a/relm4-examples/examples/factory.rs
+++ b/relm4-examples/examples/factory.rs
@@ -23,6 +23,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -118,6 +119,6 @@ fn main() {
         created_counters: 0,
     };
 
-    let relm = RelmApp::new(model);
+    let relm = RelmApp::new(model, &());
     relm.run();
 }

--- a/relm4-examples/examples/factory_advanced.rs
+++ b/relm4-examples/examples/factory_advanced.rs
@@ -30,6 +30,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -223,6 +224,6 @@ fn main() {
         received_messages: 0,
     };
 
-    let relm = RelmApp::new(model);
+    let relm = RelmApp::new(model, &());
     relm.run();
 }

--- a/relm4-examples/examples/factory_manual.rs
+++ b/relm4-examples/examples/factory_manual.rs
@@ -23,6 +23,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -144,6 +145,6 @@ fn main() {
         counter: 0,
     };
 
-    let relm = RelmApp::new(model);
+    let relm = RelmApp::new(model, &());
     relm.run();
 }

--- a/relm4-examples/examples/future.rs
+++ b/relm4-examples/examples/future.rs
@@ -25,6 +25,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl Widgets<AppModel, ()> for AppWidgets {
@@ -124,6 +125,6 @@ fn main() {
         waiting: false,
         tracker: 0,
     };
-    let relm = RelmApp::new(model);
+    let relm = RelmApp::new(model, &());
     relm.run();
 }

--- a/relm4-examples/examples/grid_factory.rs
+++ b/relm4-examples/examples/grid_factory.rs
@@ -28,6 +28,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl Widgets<AppModel, ()> for AppWidgets {
@@ -161,6 +162,6 @@ fn main() {
         data: FactoryVec::new(),
         counter: 0,
     };
-    let relm = RelmApp::new(model);
+    let relm = RelmApp::new(model, &());
     relm.run();
 }

--- a/relm4-examples/examples/list.rs
+++ b/relm4-examples/examples/list.rs
@@ -106,6 +106,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl Widgets<AppModel, ()> for AppWidgets {
@@ -281,6 +282,6 @@ fn main() {
     }
 
     let model = AppModel { store };
-    let relm = RelmApp::new(model);
+    let relm = RelmApp::new(model, &());
     relm.run();
 }

--- a/relm4-examples/examples/macro.rs
+++ b/relm4-examples/examples/macro.rs
@@ -15,6 +15,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -67,6 +68,6 @@ fn main() {
         counter: 0,
         tracker: 0,
     };
-    let relm = RelmApp::new(model);
+    let relm = RelmApp::new(model, &());
     relm.run();
 }

--- a/relm4-examples/examples/macro_test.rs
+++ b/relm4-examples/examples/macro_test.rs
@@ -19,6 +19,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = AppComponents;
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -50,10 +51,11 @@ impl Model for ButtonModel {
     type Msg = ButtonMsg;
     type Widgets = ButtonWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl ComponentUpdate<AppModel> for ButtonModel {
-    fn init_model(_parent_model: &AppModel) -> Self {
+    fn init_model(_parent_model: &AppModel, _parent_settings: &Self::Settings) -> Self {
         ButtonModel {}
     }
 
@@ -86,10 +88,11 @@ impl Components<AppModel> for AppComponents {
         model: &AppModel,
         parent_widgets: &AppWidgets,
         sender: Sender<AppMsg>,
+        _settings: &(),
     ) -> Self {
         AppComponents {
-            button1: RelmComponent::new(model, parent_widgets, sender.clone()),
-            button2: RelmComponent::new(model, parent_widgets, sender),
+            button1: RelmComponent::new(model, parent_widgets, sender.clone(), &()),
+            button2: RelmComponent::new(model, parent_widgets, sender, &()),
         }
     }
 }
@@ -176,6 +179,6 @@ fn main() {
         classes: vec!["first", "second"],
         decrement: false,
     };
-    let app = RelmApp::new(model);
+    let app = RelmApp::new(model, &());
     app.run();
 }

--- a/relm4-examples/examples/non_blocking_async.rs
+++ b/relm4-examples/examples/non_blocking_async.rs
@@ -21,6 +21,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = AppComponents;
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -104,6 +105,7 @@ impl Components<AppModel> for AppComponents {
         parent_model: &AppModel,
         _parent_widget: &AppWidgets,
         parent_sender: Sender<AppMsg>,
+        _settings: &(),
     ) -> Self {
         AppComponents {
             async_handler: RelmMsgHandler::new(parent_model, parent_sender),
@@ -145,6 +147,6 @@ impl Widgets<AppModel, ()> for AppWidgets {
 
 fn main() {
     let model = AppModel { counter: 0 };
-    let app = RelmApp::new(model);
+    let app = RelmApp::new(model, &());
     app.run();
 }

--- a/relm4-examples/examples/non_blocking_async_manual.rs
+++ b/relm4-examples/examples/non_blocking_async_manual.rs
@@ -25,6 +25,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -106,6 +107,6 @@ fn main() {
         counter: 0,
         async_handler: rx,
     };
-    let app = RelmApp::new(model);
+    let app = RelmApp::new(model, &());
     app.run();
 }

--- a/relm4-examples/examples/open_button.rs
+++ b/relm4-examples/examples/open_button.rs
@@ -16,6 +16,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = AppComponents;
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -41,16 +42,13 @@ impl OpenButtonParent for AppModel {
             text: "Open file",
             recently_opened_files: Some(".recent_files"),
             max_recent_files: 10,
-        }
-    }
-
-    fn dialog_config(&self) -> OpenDialogSettings {
-        OpenDialogSettings {
-            accept_label: "Open",
-            cancel_label: "Cancel",
-            create_folders: true,
-            is_modal: true,
-            filters: Vec::new(),
+            dialog: OpenDialogSettings {
+                accept_label: "Open",
+                cancel_label: "Cancel",
+                create_folders: true,
+                is_modal: true,
+                filters: Vec::new(),
+            }
         }
     }
 
@@ -74,9 +72,10 @@ impl Components<AppModel> for AppComponents {
         model: &AppModel,
         parent_widgets: &AppWidgets,
         sender: Sender<AppMsg>,
+        _settings: &(),
     ) -> Self {
         AppComponents {
-            open_button: RelmComponent::new(model, parent_widgets, sender),
+            open_button: RelmComponent::new(model, parent_widgets, sender, &model.open_button_config()),
         }
     }
 }
@@ -96,6 +95,6 @@ impl Widgets<AppModel, ()> for AppWidgets {
 
 fn main() {
     let model = AppModel {};
-    let app = RelmApp::new(model);
+    let app = RelmApp::new(model, &());
     app.run();
 }

--- a/relm4-examples/examples/popover.rs
+++ b/relm4-examples/examples/popover.rs
@@ -15,6 +15,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -78,6 +79,6 @@ impl Widgets<AppModel, ()> for AppWidgets {
 
 fn main() {
     let model = AppModel::default();
-    let app = RelmApp::new(model);
+    let app = RelmApp::new(model, &());
     app.run();
 }

--- a/relm4-examples/examples/save_dialog.rs
+++ b/relm4-examples/examples/save_dialog.rs
@@ -25,6 +25,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = AppComponents;
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -81,9 +82,10 @@ impl Components<AppModel> for AppComponents {
         model: &AppModel,
         parent_widgets: &AppWidgets,
         sender: Sender<AppMsg>,
+        _settings: &(),
     ) -> Self {
         AppComponents {
-            dialog: RelmComponent::new(model, parent_widgets, sender),
+            dialog: RelmComponent::new(model, parent_widgets, sender, &model.dialog_config()),
         }
     }
 }
@@ -129,6 +131,6 @@ impl Widgets<AppModel, ()> for AppWidgets {
 
 fn main() {
     let model = AppModel::default();
-    let app = RelmApp::new(model);
+    let app = RelmApp::new(model, &());
     app.run();
 }

--- a/relm4-examples/examples/simple.rs
+++ b/relm4-examples/examples/simple.rs
@@ -15,6 +15,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -65,6 +66,6 @@ impl Widgets<AppModel, ()> for AppWidgets {
 
 fn main() {
     let model = AppModel::default();
-    let app = RelmApp::new(model);
+    let app = RelmApp::new(model, &());
     app.run();
 }

--- a/relm4-examples/examples/simple_manual.rs
+++ b/relm4-examples/examples/simple_manual.rs
@@ -14,6 +14,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -95,6 +96,6 @@ impl Widgets<AppModel, ()> for AppWidgets {
 
 fn main() {
     let model = AppModel { counter: 0 };
-    let app = RelmApp::new(model);
+    let app = RelmApp::new(model, &());
     app.run();
 }

--- a/relm4-examples/examples/stack.rs
+++ b/relm4-examples/examples/stack.rs
@@ -39,6 +39,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -108,6 +109,6 @@ impl Widgets<AppModel, ()> for AppWidgets {
 
 fn main() {
     let model = AppModel { page: Page::Hello };
-    let app = RelmApp::new(model);
+    let app = RelmApp::new(model, &());
     app.run();
 }

--- a/relm4-examples/examples/stateful_msg_handler.rs
+++ b/relm4-examples/examples/stateful_msg_handler.rs
@@ -22,6 +22,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = AppComponents;
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -112,6 +113,7 @@ impl Components<AppModel> for AppComponents {
         parent_model: &AppModel,
         _parent_widget: &AppWidgets,
         parent_sender: Sender<AppMsg>,
+        _settings: &(),
     ) -> Self {
         AppComponents {
             async_handler: RelmMsgHandler::new(parent_model, parent_sender),
@@ -153,6 +155,6 @@ impl Widgets<AppModel, ()> for AppWidgets {
 
 fn main() {
     let model = AppModel { counter: 0 };
-    let app = RelmApp::new(model);
+    let app = RelmApp::new(model, &());
     app.run();
 }

--- a/relm4-examples/examples/to_do.rs
+++ b/relm4-examples/examples/to_do.rs
@@ -70,6 +70,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -129,6 +130,6 @@ fn main() {
     let model = AppModel {
         tasks: FactoryVec::new(),
     };
-    let relm = RelmApp::new(model);
+    let relm = RelmApp::new(model, &());
     relm.run();
 }

--- a/relm4-examples/examples/tokio.rs
+++ b/relm4-examples/examples/tokio.rs
@@ -12,6 +12,7 @@ impl Model for HttpModel {
     type Msg = HttpMsg;
     type Widgets = ();
     type Components = ();
+    type Settings = ();
 }
 
 enum HttpMsg {
@@ -74,9 +75,10 @@ impl Components<AppModel> for AppComponents {
         parent_model: &AppModel,
         _parent_widgets: &AppWidgets,
         parent_sender: Sender<AppMsg>,
+        _settings: &(),
     ) -> Self {
         AppComponents {
-            http: AsyncRelmWorker::with_new_tokio_rt(parent_model, parent_sender),
+            http: AsyncRelmWorker::with_new_tokio_rt(parent_model, parent_sender, &()),
         }
     }
 }
@@ -100,6 +102,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = AppComponents;
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -267,6 +270,6 @@ fn main() {
         image_waiting: false,
         tracker: 0,
     };
-    let relm = RelmApp::new(model);
+    let relm = RelmApp::new(model, &());
     relm.run();
 }

--- a/relm4-examples/examples/tracker.rs
+++ b/relm4-examples/examples/tracker.rs
@@ -36,6 +36,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -112,6 +113,6 @@ fn main() {
         identical: false,
         tracker: 0,
     };
-    let relm = RelmApp::new(model);
+    let relm = RelmApp::new(model, &());
     relm.run();
 }

--- a/relm4-examples/libadwaita/examples/simple.rs
+++ b/relm4-examples/libadwaita/examples/simple.rs
@@ -16,6 +16,7 @@ impl Model for AppModel {
     type Msg = AppMsg;
     type Widgets = AppWidgets;
     type Components = ();
+    type Settings = ();
 }
 
 impl AppUpdate for AppModel {
@@ -76,6 +77,6 @@ impl Widgets<AppModel, ()> for AppWidgets {
 
 fn main() {
     let model = AppModel::default();
-    let app = RelmApp::new(model);
+    let app = RelmApp::new(model, &());
     app.run();
 }

--- a/relm4-macros/src/lib.rs
+++ b/relm4-macros/src/lib.rs
@@ -52,6 +52,7 @@ use types::ModelTypes;
 ///     type Msg = AppMsg;
 ///     type Widgets = AppWidgets;
 ///     type Components = ();
+///     type Settings = ();
 /// }
 ///
 /// impl AppUpdate for AppModel {

--- a/src/app.rs
+++ b/src/app.rs
@@ -38,7 +38,7 @@ where
     }
 
     /// Create an application.
-    pub fn new(mut model: Model) -> Self {
+    pub fn new(mut model: Model, settings: &Model::Settings) -> Self {
         gtk::init().expect("Couln't initialize GTK");
         let app = gtk::Application::builder().build();
         crate::APP
@@ -50,7 +50,7 @@ where
         let mut widgets = Model::Widgets::init_view(&model, &(), sender.clone());
         let root = widgets.root_widget();
 
-        let components = Model::Components::init_components(&model, &widgets, sender.clone());
+        let components = Model::Components::init_components(&model, &widgets, sender.clone(), settings);
 
         widgets.connect_components(&model, &components);
 

--- a/src/component.rs
+++ b/src/component.rs
@@ -35,15 +35,16 @@ where
         parent_model: &ParentModel,
         parent_widgets: &ParentModel::Widgets,
         parent_sender: Sender<ParentModel::Msg>,
+        settings: &Model::Settings,
     ) -> Self {
         let (sender, receiver) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
 
-        let mut model = Model::init_model(parent_model);
+        let mut model = Model::init_model(parent_model, settings);
 
         let mut widgets = Model::Widgets::init_view(&model, parent_widgets, sender.clone());
         let root_widget = widgets.root_widget();
 
-        let components = Model::Components::init_components(&model, &widgets, sender.clone());
+        let components = Model::Components::init_components(&model, &widgets, sender.clone(), settings);
         let cloned_sender = sender.clone();
 
         widgets.connect_components(&model, &components);
@@ -102,16 +103,17 @@ where
         parent_model: &ParentModel,
         parent_widgets: &ParentModel::Widgets,
         parent_sender: Sender<ParentModel::Msg>,
+        settings: &Model::Settings,
     ) -> Self {
         let (global_sender, global_receiver) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
         let (sender, receiver) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
 
-        let model = Model::init_model(parent_model);
+        let model = Model::init_model(parent_model, settings);
 
         let mut widgets = Model::Widgets::init_view(&model, parent_widgets, sender.clone());
         let root_widget = widgets.root_widget();
 
-        let components = Model::Components::init_components(&model, &widgets, sender.clone());
+        let components = Model::Components::init_components(&model, &widgets, sender.clone(), settings);
         let cloned_sender = sender.clone();
 
         widgets.connect_components(&model, &components);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/AaronErhardt/relm4/main/assets/Relm_logo.svg"
 )]
+#![feature(doc_cfg)]
 
 mod app;
 mod component;

--- a/src/traits/impls.rs
+++ b/src/traits/impls.rs
@@ -5,6 +5,7 @@ impl Model for () {
     type Msg = ();
     type Widgets = ();
     type Components = ();
+    type Settings = ();
 }
 
 impl<ModelType, ParentModel> Widgets<ModelType, ParentModel> for ()
@@ -33,6 +34,7 @@ impl<ParentModel: Model> Components<ParentModel> for () {
         _parent_model: &ParentModel,
         _widgets: &ParentModel::Widgets,
         _sender: Sender<ParentModel::Msg>,
+        _parent_settings: &ParentModel::Settings,
     ) {
     }
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -25,6 +25,7 @@ mod impls;
 ///     type Msg = AppMsg;
 ///     type Widgets = AppWidgets;
 ///     type Components = ();
+///     type Settings = ();
 /// }
 /// ```
 pub trait Model: std::marker::Sized {
@@ -40,6 +41,9 @@ pub trait Model: std::marker::Sized {
     ///
     /// If you don't want any component associated with this model just use `()`.
     type Components: Components<Self>;
+
+    /// Settings used to initialize component
+    type Settings;
 }
 
 /// Define the behavior to update the model of the main app.
@@ -63,6 +67,7 @@ pub trait Model: std::marker::Sized {
 /// #     type Msg = AppMsg;
 /// #     type Widgets = AppWidgets;
 /// #     type Components = ();
+/// #     type Settings = ();
 /// # }
 /// #
 /// impl AppUpdate for AppModel {
@@ -101,7 +106,7 @@ pub trait ComponentUpdate<ParentModel: Model>: Model {
     ///
     /// In case you want to share information or settings with the parent component you
     /// get the parent's model passed as parameter.
-    fn init_model(parent_model: &ParentModel) -> Self;
+    fn init_model(parent_model: &ParentModel, settings: &Self::Settings) -> Self;
 
     /// Updates the model.
     /// Typically a `match` statement is used to process the message.
@@ -200,26 +205,31 @@ where
 /// #     type Msg = AppMsg;
 /// #     type Widgets = AppWidgets;
 /// #     type Components = ();
+/// #     type Settings = ();
 /// # }
 /// #
 /// # struct CompMsg {};
-/// # struct Comp1Model {};
+/// # struct Comp1Settings {};
+/// # struct Comp1Model {}
+/// # struct Comp2Settings {};
 /// # struct Comp2Model {};
 /// #
 /// # impl Model for Comp1Model {
 /// #     type Msg = CompMsg;
 /// #     type Widgets = ();
 /// #     type Components = ();
+/// #     type Settings = Comp1Settings;
 /// # }
 /// #
 /// # impl Model for Comp2Model {
 /// #     type Msg = CompMsg;
 /// #     type Widgets = ();
 /// #     type Components = ();
+/// #     type Settings = Comp2Settings;
 /// # }
 /// #
 /// # impl ComponentUpdate<AppModel> for Comp1Model {
-/// #     fn init_model(_parent_model: &AppModel) -> Self {
+/// #     fn init_model(_parent_model: &AppModel, _settings: &Self::Settings) -> Self {
 /// #         Comp1Model {}
 /// #     }
 /// #
@@ -233,7 +243,7 @@ where
 /// # }
 /// #
 /// # impl ComponentUpdate<AppModel> for Comp2Model {
-/// #     fn init_model(_parent_model: &AppModel) -> Self {
+/// #     fn init_model(_parent_model: &AppModel, _settings: &Self::Settings) -> Self {
 /// #         Comp2Model {}
 /// #     }
 /// #
@@ -252,10 +262,10 @@ where
 /// }
 ///
 /// impl Components<AppModel> for AppComponents {
-///     fn init_components(parent_model: &AppModel, parent_widgets: &AppWidgets, parent_sender: Sender<AppMsg>) -> Self {
+///     fn init_components(parent_model: &AppModel, parent_widgets: &AppWidgets, parent_sender: Sender<AppMsg>, _settings: &()) -> Self {
 ///         AppComponents {
-///             comp1: RelmComponent::with_new_thread(parent_model, parent_widgets, parent_sender.clone()),
-///             comp2: RelmComponent::new(parent_model, parent_widgets, parent_sender),
+///             comp1: RelmComponent::with_new_thread(parent_model, parent_widgets, parent_sender.clone(), &Comp1Settings{}),
+///             comp2: RelmComponent::new(parent_model, parent_widgets, parent_sender, &Comp2Settings{}),
 ///         }
 ///     }
 /// }
@@ -266,6 +276,7 @@ pub trait Components<ParentModel: ?Sized + Model> {
         parent_model: &ParentModel,
         parent_widget: &ParentModel::Widgets,
         parent_sender: Sender<ParentModel::Msg>,
+        parent_settings: &ParentModel::Settings,
     ) -> Self;
 }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -32,12 +32,16 @@ where
     ParentModel: ModelTrait,
 {
     /// Create a new [`RelmWorker`] that runs on the main thread.
-    pub fn new(parent_model: &ParentModel, parent_sender: Sender<ParentModel::Msg>) -> Self {
+    pub fn new(
+        parent_model: &ParentModel, 
+        parent_sender: Sender<ParentModel::Msg>,
+        settings: &Model::Settings,
+    ) -> Self {
         let (sender, receiver) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
 
-        let mut model = Model::init_model(parent_model);
+        let mut model = Model::init_model(parent_model, settings);
 
-        let components = Model::Components::init_components(&model, &(), sender.clone());
+        let components = Model::Components::init_components(&model, &(), sender.clone(), settings);
         let cloned_sender = sender.clone();
 
         {
@@ -78,12 +82,13 @@ where
     pub fn with_new_thread(
         parent_model: &ParentModel,
         parent_sender: Sender<ParentModel::Msg>,
+        settings: &Model::Settings,
     ) -> Self {
         let (sender, receiver) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
 
-        let mut model = Model::init_model(parent_model);
+        let mut model = Model::init_model(parent_model, settings);
 
-        let components = Model::Components::init_components(&model, &(), sender.clone());
+        let components = Model::Components::init_components(&model, &(), sender.clone(), settings);
         let cloned_sender = sender.clone();
 
         std::thread::spawn(move || {
@@ -149,12 +154,13 @@ where
     pub fn with_new_tokio_rt(
         parent_model: &ParentModel,
         parent_sender: Sender<ParentModel::Msg>,
+        settings: &Model::Settings
     ) -> Self {
         let (sender, receiver) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
 
         let mut model = Model::init_model(parent_model);
 
-        let components = Model::Components::init_components(&model, &(), sender.clone());
+        let components = Model::Components::init_components(&model, &(), sender.clone(), settings);
         let cloned_sender = sender.clone();
 
         std::thread::spawn(move || {


### PR DESCRIPTION
Model contains new dependant type `Settings`. This
type is passed around so it's easy to differentiate
multiple compnents configuration, dependant on the call.