### PR TITLE
Make factory key unsized

### DIFF
--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -62,7 +62,7 @@ where
     View: FactoryView<Data::Root>,
 {
     /// Key that provides additional information for the [`FactoryPrototype`] functions.
-    type Key;
+    type Key: ?Sized;
 
     /// Efficiently update the view according to data changes.
     fn generate(&self, view: &View, sender: Sender<Data::Msg>);


### PR DESCRIPTION
This reduces constraints on `Factory::Key` so implementing factory for
generic key becomes possible.

relm4-store-record `Id` is generic in terms of values which it holds.
It's user responsibility to provide values "good enough" for id to have
a meaning.