### PR TITLE
wrap tokens from `manual_view` in an IIFE

### DIFF
--- a/relm4-macros/src/lib.rs
+++ b/relm4-macros/src/lib.rs
@@ -267,7 +267,8 @@ pub fn widget(attributes: TokenStream, input: TokenStream) -> TokenStream {
 
             /// Update the view to represent the updated model.
             fn view(&mut self, model: &#model, sender: #relm4_path::Sender<<#model as #relm4_path::Model>::Msg>) {
-                #manual_view
+                // Wrap manual view code to prevent early returns from skipping other view code.
+                (|| { #manual_view })();
                 #view
                 #track
             }


### PR DESCRIPTION
I tried writing a `manual_view` function in my `view!` macro like this:

```rust
    fn manual_view(&self) {
        let file = match &model.file {
            Some(file) => file,
            None => return,
        };

        match &file.preview {
            FilePreview::Image(path) => {
                self.image.set_file(Some(&path.to_string_lossy()));
            }
            FilePreview::Icon(icon) => {
                self.image.set_gicon(Some(icon));
            }
        }
    }
```

This led to some strange behavior in my application, where certain widgets were containing stale data. Expanding the macro revealed the problem:

```rust
        /// Update the view to represent the updated model.
        fn view(
            &mut self,
            model: &FilePreviewModel,
            sender: ::relm4::Sender<<FilePreviewModel as ::relm4::Model>::Msg>,
        ) {
            let file = match &model.file {
                Some(file) => file,
                None => return,
            };

            match &file.preview {
                FilePreview::Image(path) => {
                    self.image.set_file(Some(&path.to_string_lossy()));
                }
                FilePreview::Icon(icon) => {
                    self.image.set_gicon(Some(icon));
                }
            }

            // code generated from view macro...
        }
```

The early return was causing the generated view code to be skipped. This PR fixes the issue by wrapping the tokens from `manual_view` in an IIFE. This causes early returns in `manual_view` to only return from the manual code, instead of skipping the rest of the view code.