### PR TITLE
Allow root widget to be any type

### DIFF
--- a/src/component/bridge.rs
+++ b/src/component/bridge.rs
@@ -16,6 +16,14 @@ pub struct Bridge<Component, Root> {
     pub(super) component: PhantomData<Component>,
 }
 
+impl<Component, Root> Bridge<Component, Root> {
+    /// Configure the root widget before launching.
+    pub fn preflight<F: FnOnce(&mut Root) + 'static>(mut self, func: F) -> Self {
+        func(&mut self.root);
+        self
+    }
+}
+
 impl<Component, Root: AsRef<gtk::Widget>> Bridge<Component, Root> {
     /// Attach the component's root widget to a given container.
     pub fn attach_to(self, container: &impl RelmContainerExt) -> Self {

--- a/src/component/bridge.rs
+++ b/src/component/bridge.rs
@@ -16,14 +16,16 @@ pub struct Bridge<Component, Root> {
     pub(super) component: PhantomData<Component>,
 }
 
-impl<C: Component> Bridge<C, C::Root> {
+impl<Component, Root: AsRef<gtk::Widget>> Bridge<Component, Root> {
     /// Attach the component's root widget to a given container.
     pub fn attach_to(self, container: &impl RelmContainerExt) -> Self {
         container.container_add(self.root.as_ref());
 
         self
     }
+}
 
+impl<C: Component> Bridge<C, C::Root> {
     /// Starts the component, passing ownership to a future attached to a GLib context.
     pub fn launch(self, payload: C::Payload) -> Fairing<C::Root, C::Input, C::Output> {
         let Bridge { root, .. } = self;

--- a/src/component/elm_like.rs
+++ b/src/component/elm_like.rs
@@ -46,20 +46,25 @@ pub trait Component: Sized + 'static {
     ) -> Fuselage<Self, Self::Widgets>;
 
     /// Processes inputs received by the component.
+    #[allow(unused)]
     fn update(
         &mut self,
         message: Self::Input,
         input: &mut Sender<Self::Input>,
         output: &mut Sender<Self::Output>,
-    ) -> Option<Self::Command>;
+    ) -> Option<Self::Command> {
+        None
+    }
 
     /// Updates the view after the model has been updated.
+    #[allow(unused)]
     fn update_view(
         &self,
         widgets: &mut Self::Widgets,
         input: &mut Sender<Self::Input>,
         output: &mut Sender<Self::Output>,
-    );
+    ) {
+    }
 
     /// A command to perform in a background thread.
     #[allow(unused)]

--- a/src/component/elm_like.rs
+++ b/src/component/elm_like.rs
@@ -21,7 +21,7 @@ pub trait Component: Sized + 'static {
     type Payload;
 
     /// The widget that was constructed by the component.
-    type Root: Clone + OnDestroy + AsRef<gtk::Widget>;
+    type Root: Clone + OnDestroy;
 
     /// The type that's used for storing widgets created for this component.
     type Widgets: 'static;

--- a/src/component/elm_like.rs
+++ b/src/component/elm_like.rs
@@ -21,7 +21,7 @@ pub trait Component: Sized + 'static {
     type Payload;
 
     /// The widget that was constructed by the component.
-    type Root: Clone + OnDestroy;
+    type Root: OnDestroy;
 
     /// The type that's used for storing widgets created for this component.
     type Widgets: 'static;

--- a/src/component/stateful.rs
+++ b/src/component/stateful.rs
@@ -21,7 +21,7 @@ pub trait StatefulComponent: Sized + 'static {
     type Payload;
 
     /// The widget that was constructed by the component.
-    type Root: Clone + OnDestroy + AsRef<gtk::Widget>;
+    type Root: Clone + OnDestroy;
 
     /// The type that's used for storing widgets created for this component.
     type Widgets: 'static;

--- a/src/component/stateful.rs
+++ b/src/component/stateful.rs
@@ -46,13 +46,16 @@ pub trait StatefulComponent: Sized + 'static {
     ) -> Fuselage<Self, Self::Widgets>;
 
     /// Processes inputs received by the component.
+    #[allow(unused)]
     fn update(
         &mut self,
         widgets: &mut Self::Widgets,
         message: Self::Input,
         input: &mut Sender<Self::Input>,
         output: &mut Sender<Self::Output>,
-    ) -> Option<Self::Command>;
+    ) -> Option<Self::Command> {
+        None
+    }
 
     /// A command to perform in a background thread.
     #[allow(unused)]

--- a/src/component/stateful.rs
+++ b/src/component/stateful.rs
@@ -21,7 +21,7 @@ pub trait StatefulComponent: Sized + 'static {
     type Payload;
 
     /// The widget that was constructed by the component.
-    type Root: Clone + OnDestroy;
+    type Root: OnDestroy;
 
     /// The type that's used for storing widgets created for this component.
     type Widgets: 'static;


### PR DESCRIPTION
- Makes the `Bridge::attach_to` method available for `StatefulComponent` types
- Permits components to have any type as the root widget, instead of just GTK widgets
- Adds `Bridge::preflight` for pre-launch configuration for everything else