### PR TITLE
README.md: proc_macro now imported from relm4, not relm4_macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ impl AppUpdate for AppModel {
     }
 }
 
-#[relm4_macros::widget]
+#[relm4::widget]
 impl Widgets<AppModel, ()> for AppWidgets {
     view! {
         gtk::ApplicationWindow {


### PR DESCRIPTION
The code example from README.md does not compile.

It still shows using `#[relm4_macros::widget]` as the derive macro, which I assume would be correct if the `relm4_macros` crate was pulled in as a direct dependency of the code.

However, README.md recommends importing macros via the `macros` feature on the `relm4` crate, and the code -- as given -- does not work that way.

It would massively help new users, such as myself, if the example in the README could be run as-is.

This is such a simple change -- I hope it's OK that I submit this directly as a pull request, rather than filing an issue.