### PR TITLE
Fix FactoryVec state changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,7 @@ macros = ["relm4-macros"]
 all = ["tokio-rt", "libadwaita", "macros"]
 
 [dev-dependencies]
+futures-channel = "0.3"
+futures-executor = "0.3"
 # Macros required to run tests.
 relm4-macros = { path = "relm4-macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ libadwaita = ["adw"]
 tokio-rt = ["tokio", "async-trait"]
 macros = ["relm4-macros"]
 all = ["tokio-rt", "libadwaita", "macros"]
+
+[dev-dependencies]
+# Macros required to run tests.
+relm4-macros = { path = "relm4-macros" }

--- a/src/factory/collections/factory_vec.rs
+++ b/src/factory/collections/factory_vec.rs
@@ -68,12 +68,7 @@ where
 
     /// Remove all data from the [`FactoryVec`].
     pub fn clear(&mut self) {
-        let changes = &mut self.changes.borrow_mut();
-
-        for idx in 0..self.data.len() {
-            changes.insert(idx, ChangeType::Remove);
-        }
-        self.data.clear();
+        while self.pop().is_some() {}
     }
 
     /// Returns the length as amount of elements stored in this type.
@@ -86,27 +81,68 @@ where
         self.data.is_empty()
     }
 
+    // This comment explains the idea of how the state of this struct is kept
+    // consistent. By modelling the state of each field in the vector as a state
+    // machine, we have an easier time making sure that any operation performed
+    // on the struct leaves it in a well-defined state. Here is a minimal
+    // representation of this state-machine:
+    //
+    // `````````````````````````````````
+    //     NoneO ⇄ Add
+    //     NoneX → Remove ⇄ Recreate
+    // `````````````````````````````````
+    //
+    // This state machine for a field in our struct consists of two kinds of
+    // transitions (push, pop) and of these five states:
+    // - [X ] Add        A widget is to be added for this field
+    // - [O*] Remove     The widget for this field is to be removed
+    // - [X*] Recreate   A new widget is replacing the current one
+    // - [X*] NoneX      No change to occur, data and widget exist
+    // - [O ] NoneO      No change to occur, no data nor widget
+    //
+    // Here the X annotation means, the field is currently backed by data, which
+    // will be used to generate a widget on the next call to `generate`. On the
+    // other hand, O means that it is *not* backed. The star * indicates there
+    // currently exists a widget for this field. By assuming we can initially
+    // start only in one of the two None states (i.e. with an empty change list)
+    // and with the given reasonably well eyeballed transition types, no other
+    // combinations can occur or are required. The two types of transitions
+    // between states are adding and removing data, i.e., executing push or pop.
+    // Adding can only start from states marked with O, while removing can only
+    // happen from states marked with X. (The cases where these operations make
+    // sense.)
+    //
+    // Note that the `Update` ChangeType is not explicitly included here. This
+    // is because, regarding the transitions, it has the same semantics as NoneX
+    // and can be treated equivalently.
+
     /// Insert an element at the end of a [`FactoryVec`].
     pub fn push(&mut self, data: Data) {
         let index = self.data.len();
         self.data.push(data);
 
         let change = match self.changes.borrow().get(&index) {
-            Some(ChangeType::Recreate | ChangeType::Remove) => ChangeType::Recreate,
-            _ => ChangeType::Add,
+            None => ChangeType::Add,
+            Some(ChangeType::Remove) => ChangeType::Recreate,
+            Some(ChangeType::Add | ChangeType::Recreate | ChangeType::Update) => unreachable!(),
         };
-        self.changes.borrow_mut().insert(index, change);
+        self.set_change(index, Some(change));
     }
 
     /// Remove an element at the end of a [`FactoryVec`].
     pub fn pop(&mut self) -> Option<Data> {
-        let data = self.data.pop();
-        if data.is_some() {
-            let index = self.data.len();
-            self.changes.borrow_mut().insert(index, ChangeType::Remove);
-        }
+        let data = self.data.pop()?;
+        let index = self.data.len();
 
-        data
+        let change = match self.changes.borrow().get(&index) {
+            None | Some(ChangeType::Update) => Some(ChangeType::Remove),
+            Some(ChangeType::Add) => None,
+            Some(ChangeType::Recreate) => Some(ChangeType::Remove),
+            Some(ChangeType::Remove) => unreachable!(),
+        };
+        self.set_change(index, change);
+
+        Some(data)
     }
 
     /// Get a reference to data stored at `index`.
@@ -121,10 +157,19 @@ where
     /// needs to be updated.
     #[must_use]
     pub fn get_mut(&mut self, index: usize) -> Option<&mut Data> {
+        let data = self.data.get_mut(index)?;
         let mut changes = self.changes.borrow_mut();
         changes.entry(index).or_insert(ChangeType::Update);
+        Some(data)
+    }
 
-        self.data.get_mut(index)
+    /// Sets the change to be performed for a given index, None for reset.
+    fn set_change(&self, index: usize, change: Option<ChangeType>) {
+        if let Some(change) = change {
+            self.changes.borrow_mut().insert(index, change);
+        } else {
+            self.changes.borrow_mut().remove(&index);
+        }
     }
 }
 
@@ -136,14 +181,19 @@ where
     type Key = usize;
 
     fn generate(&self, view: &View, sender: Sender<Data::Msg>) {
+        // Compensate for removals changing the data under us.
+        let mut neg_index_adjustment = 0;
+
+        // Iterate from smallest to biggest index.
         for (index, change) in self.changes.borrow().iter() {
+            let index = *index - neg_index_adjustment;
             let mut widgets = self.widgets.borrow_mut();
 
             match change {
                 ChangeType::Add => {
-                    let data = &self.data[*index];
-                    let new_widgets = data.init_view(index, sender.clone());
-                    let position = data.position(index);
+                    let data = &self.data[index];
+                    let new_widgets = data.init_view(&index, sender.clone());
+                    let position = data.position(&index);
                     let root = view.add(Data::root_widget(&new_widgets), &position);
                     widgets.push(Widgets {
                         widgets: new_widgets,
@@ -151,23 +201,26 @@ where
                     });
                 }
                 ChangeType::Update => {
-                    self.data[*index].view(index, &widgets[*index].widgets);
+                    self.data[index].view(&index, &widgets[index].widgets);
                 }
                 ChangeType::Remove => {
-                    let remove_widget = widgets.pop().unwrap();
+                    let remove_widget = widgets.remove(index);
                     view.remove(&remove_widget.root);
+                    neg_index_adjustment += 1;
                 }
                 ChangeType::Recreate => {
-                    let remove_widget = widgets.pop().unwrap();
-                    view.remove(&remove_widget.root);
-                    let data = &self.data[*index];
-                    let new_widgets = data.init_view(index, sender.clone());
-                    let position = data.position(index);
+                    let data = &self.data[index];
+                    let new_widgets = data.init_view(&index, sender.clone());
+                    let position = data.position(&index);
                     let root = view.add(Data::root_widget(&new_widgets), &position);
-                    widgets.push(Widgets {
-                        widgets: new_widgets,
-                        root,
-                    });
+                    let remove_widget = std::mem::replace(
+                        &mut widgets[index],
+                        Widgets {
+                            widgets: new_widgets,
+                            root,
+                        },
+                    );
+                    view.remove(&remove_widget.root);
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,3 +130,38 @@ macro_rules! send {
         $sender.send($msg).expect("Receiver was dropped!")
     };
 }
+
+// Adapted from gtk4-rs
+#[cfg(test)]
+fn test_synced<F, R>(function: F) -> R
+where
+    F: FnOnce() -> R + Send + std::panic::UnwindSafe + 'static,
+    R: Send + 'static,
+{
+    // skip_assert_initialized!();
+
+    use futures_channel::oneshot;
+    use std::panic;
+
+    let (tx, rx) = oneshot::channel();
+    TEST_THREAD_WORKER
+        .push(move || {
+            tx.send(panic::catch_unwind(function))
+                .unwrap_or_else(|_| panic!("Failed to return result from thread pool"));
+        })
+        .expect("Failed to schedule a test call");
+    futures_executor::block_on(rx)
+        .expect("Failed to receive result from thread pool")
+        .unwrap_or_else(|e| std::panic::resume_unwind(e))
+}
+
+#[cfg(test)]
+static TEST_THREAD_WORKER: once_cell::sync::Lazy<gtk::glib::ThreadPool> =
+    once_cell::sync::Lazy::new(|| {
+        let pool = gtk::glib::ThreadPool::exclusive(1).unwrap();
+        pool.push(move || {
+            gtk::init().expect("Tests failed to initialize gtk");
+        })
+        .expect("Failed to schedule a test call");
+        pool
+    });


### PR DESCRIPTION
`FactoryVec` was acting weird and all over the place for me and it might be #84, too. I had some fun and modeled its fields as a state machine. Brings `push`, `pop`, and `clear` in line with the described model and fixes the indexing problems in the `generate` method. I think it is (more) correct now, but one could probably be smarter about `clear` and the use of `Vec::remove`.