### PR TITLE
Extend container extension traits

### DIFF
--- a/src/extensions/container.rs
+++ b/src/extensions/container.rs
@@ -1,9 +1,17 @@
 use gtk::prelude::*;
 
+use crate::RelmSetChildExt;
+
 /// Widget types which can have widgets attached to them.
 pub trait RelmContainerExt {
     /// Add widget as child to container.
     fn container_add(&self, widget: &impl AsRef<gtk::Widget>);
+}
+
+impl<T: RelmSetChildExt> RelmContainerExt for T {
+    fn container_add(&self, widget: &impl AsRef<gtk::Widget>) {
+        self.container_set_child(Some(widget));
+    }
 }
 
 macro_rules! append_impl {
@@ -12,18 +20,6 @@ macro_rules! append_impl {
             impl RelmContainerExt for $type {
                 fn container_add(&self, widget: &impl AsRef<gtk::Widget>) {
                     self.append(widget.as_ref());
-                }
-            }
-        )+
-    }
-}
-
-macro_rules! set_child_impl {
-    ($($type:ty),+) => {
-        $(
-            impl RelmContainerExt for $type {
-                fn container_add(&self, widget: &impl AsRef<gtk::Widget>) {
-                    self.set_child(Some(widget.as_ref()));
                 }
             }
         )+
@@ -43,14 +39,4 @@ macro_rules! add_child_impl {
 }
 
 append_impl!(gtk::Box, gtk::ListBox);
-set_child_impl!(
-    gtk::Button,
-    gtk::ComboBox,
-    gtk::FlowBoxChild,
-    gtk::Frame,
-    gtk::Popover,
-    gtk::Window,
-    gtk::ApplicationWindow,
-    gtk::Dialog
-);
 add_child_impl!(gtk::InfoBar, gtk::Stack);

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1,7 +1,13 @@
 mod container;
+mod removable;
+mod set_child;
 
 #[allow(unreachable_pub)]
 pub use self::container::RelmContainerExt;
+#[allow(unreachable_pub)]
+pub use self::removable::RelmRemovableExt;
+#[allow(unreachable_pub)]
+pub use self::set_child::RelmSetChildExt;
 
 use gtk::prelude::*;
 

--- a/src/extensions/removable.rs
+++ b/src/extensions/removable.rs
@@ -1,0 +1,51 @@
+use crate::RelmSetChildExt;
+use gtk::prelude::*;
+
+/// Widget types which can have widgets removed from them.
+pub trait RelmRemovableExt {
+    /// Removes the widget from the container
+    /// if it is a child of the container.
+    fn container_remove(&self, widget: &impl AsRef<gtk::Widget>);
+}
+
+impl<T: RelmSetChildExt> RelmRemovableExt for T {
+    fn container_remove(&self, _widget: &impl AsRef<gtk::Widget>) {
+        self.container_set_child(None::<&gtk::Widget>);
+    }
+}
+
+macro_rules! remove_impl {
+    ($($type:ty),+) => {
+        $(
+            impl RelmRemovableExt for $type {
+                fn container_remove(&self, widget: &impl AsRef<gtk::Widget>) {
+                    self.remove(widget.as_ref());
+                }
+            }
+        )+
+    }
+}
+
+macro_rules! remove_child_impl {
+    ($($type:ty),+) => {
+        $(
+            impl RelmRemovableExt for $type {
+                fn container_remove(&self, widget: &impl AsRef<gtk::Widget>) {
+                    self.remove_child(widget.as_ref());
+                }
+            }
+        )+
+    }
+}
+
+remove_impl!(
+    gtk::Box,
+    gtk::Fixed,
+    gtk::Grid,
+    gtk::ActionBar,
+    gtk::FlowBox,
+    gtk::ListBox,
+    gtk::Stack,
+    gtk::HeaderBar
+);
+remove_child_impl!(gtk::InfoBar);

--- a/src/extensions/removable.rs
+++ b/src/extensions/removable.rs
@@ -2,23 +2,29 @@ use crate::RelmSetChildExt;
 use gtk::prelude::*;
 
 /// Widget types which can have widgets removed from them.
-pub trait RelmRemovableExt {
+pub trait RelmRemovableExt<W> {
     /// Removes the widget from the container
     /// if it is a child of the container.
-    fn container_remove(&self, widget: &impl AsRef<gtk::Widget>);
+    fn container_remove(&self, widget: &W);
 }
 
-impl<T: RelmSetChildExt> RelmRemovableExt for T {
-    fn container_remove(&self, _widget: &impl AsRef<gtk::Widget>) {
+impl<T: RelmSetChildExt, W: AsRef<gtk::Widget>> RelmRemovableExt<W> for T {
+    fn container_remove(&self, _widget: &W) {
         self.container_set_child(None::<&gtk::Widget>);
+    }
+}
+
+impl<W: AsRef<gtk::ListBoxRow>> RelmRemovableExt<W> for gtk::ListBox {
+    fn container_remove(&self, widget: &W) {
+        self.remove(widget.as_ref());
     }
 }
 
 macro_rules! remove_impl {
     ($($type:ty),+) => {
         $(
-            impl RelmRemovableExt for $type {
-                fn container_remove(&self, widget: &impl AsRef<gtk::Widget>) {
+            impl<W: AsRef<gtk::Widget>> RelmRemovableExt<W> for $type {
+                fn container_remove(&self, widget: &W) {
                     self.remove(widget.as_ref());
                 }
             }
@@ -29,8 +35,8 @@ macro_rules! remove_impl {
 macro_rules! remove_child_impl {
     ($($type:ty),+) => {
         $(
-            impl RelmRemovableExt for $type {
-                fn container_remove(&self, widget: &impl AsRef<gtk::Widget>) {
+            impl<W: AsRef<gtk::Widget>> RelmRemovableExt<W> for $type {
+                fn container_remove(&self, widget: &W) {
                     self.remove_child(widget.as_ref());
                 }
             }
@@ -44,7 +50,6 @@ remove_impl!(
     gtk::Grid,
     gtk::ActionBar,
     gtk::FlowBox,
-    gtk::ListBox,
     gtk::Stack,
     gtk::HeaderBar
 );

--- a/src/extensions/set_child.rs
+++ b/src/extensions/set_child.rs
@@ -1,0 +1,30 @@
+use gtk::prelude::*;
+
+/// Widget types which allow to set or unset their child.
+pub trait RelmSetChildExt {
+    /// Set a child for the container or remove it using [`None`].
+    fn container_set_child(&self, widget: Option<&impl AsRef<gtk::Widget>>);
+}
+
+macro_rules! set_child_impl {
+    ($($type:ty),+) => {
+        $(
+            impl RelmSetChildExt for $type {
+                fn container_set_child(&self, widget: Option<&impl AsRef<gtk::Widget>>) {
+                    self.set_child(widget.map(|w| w.as_ref()));
+                }
+            }
+        )+
+    }
+}
+
+set_child_impl!(
+    gtk::Button,
+    gtk::ComboBox,
+    gtk::FlowBoxChild,
+    gtk::Frame,
+    gtk::Popover,
+    gtk::Window,
+    gtk::ApplicationWindow,
+    gtk::Dialog
+);


### PR DESCRIPTION
Adds `RelmSetChildExt` and `RelmRemovableExt` and uses `RelmSetChildExt` for several `RelmContainerExt` and `RelmRemovableExt` implementations.