### PR TITLE
RFC: Rename component types

### DIFF
--- a/examples/settings_list.rs
+++ b/examples/settings_list.rs
@@ -22,7 +22,7 @@ fn main() {
             // Intiialize a component's root widget
             let component = SettingsListModel::init()
                 // Attach the root widget to the given window.
-                .attach_root(&window)
+                .attach_to(&window)
                 // Start the component service with an initial parameter
                 .launch("Settings List Demo".into())
                 // Attach the returned receiver's messages to this closure.

--- a/examples/settings_list.rs
+++ b/examples/settings_list.rs
@@ -106,7 +106,7 @@ impl Component for SettingsListModel {
     type CommandOutput = SettingsListCmdOutput;
     type Input = SettingsListInput;
     type Output = SettingsListOutput;
-    type Payload = String;
+    type InitParams = String;
     type Root = gtk::Box;
     type Widgets = SettingsListWidgets;
 
@@ -119,7 +119,7 @@ impl Component for SettingsListModel {
     }
 
     fn init_parts(
-        title: Self::Payload,
+        title: Self::InitParams,
         root: &Self::Root,
         _input: &mut Sender<Self::Input>,
         output: &mut Sender<Self::Output>,

--- a/examples/settings_list.rs
+++ b/examples/settings_list.rs
@@ -22,7 +22,7 @@ fn main() {
             // Intiialize a component's root widget
             let component = SettingsListModel::init()
                 // Attach the root widget to the given window.
-                .attach_to(&window)
+                .attach_root(&window)
                 // Start the component service with an initial parameter
                 .launch("Settings List Demo".into())
                 // Attach the returned receiver's messages to this closure.
@@ -118,12 +118,12 @@ impl Component for SettingsListModel {
             .build()
     }
 
-    fn dock(
+    fn init_parts(
         title: Self::Payload,
         root: &Self::Root,
         _input: &mut Sender<Self::Input>,
         output: &mut Sender<Self::Output>,
-    ) -> Fuselage<Self, Self::Widgets> {
+    ) -> ComponentParts<Self, Self::Widgets> {
         // Request the caller to reload its options.
         let _ = output.send(SettingsListOutput::Reload);
 
@@ -142,7 +142,7 @@ impl Component for SettingsListModel {
         root.append(&label);
         root.append(&list);
 
-        Fuselage {
+        ComponentParts {
             model: SettingsListModel::default(),
             widgets: SettingsListWidgets {
                 list,

--- a/examples/simple_manual.rs
+++ b/examples/simple_manual.rs
@@ -23,7 +23,7 @@ impl SimpleComponent for AppModel {
     type Widgets = AppWidgets;
     type Root = gtk::Window;
 
-    type Payload = u8;
+    type InitParams = u8;
 
     type Input = AppMsg;
     type Output = ();
@@ -38,7 +38,7 @@ impl SimpleComponent for AppModel {
 
     /// Initialize the UI.
     fn init_parts(
-        counter: Self::Payload,
+        counter: Self::InitParams,
         window: &Self::Root,
         input: &mut Sender<Self::Input>,
         _output: &mut Sender<Self::Output>,

--- a/examples/simple_manual.rs
+++ b/examples/simple_manual.rs
@@ -1,5 +1,5 @@
 use gtk::prelude::{BoxExt, ButtonExt, GtkWindowExt};
-use relm4::{gtk, send, Fuselage, RelmApp, Sender, SimpleComponent, WidgetPlus};
+use relm4::{gtk, send, ComponentParts, RelmApp, Sender, SimpleComponent, WidgetPlus};
 
 struct AppModel {
     counter: u8,
@@ -37,12 +37,12 @@ impl SimpleComponent for AppModel {
     }
 
     /// Initialize the UI.
-    fn dock(
+    fn init_parts(
         counter: Self::Payload,
         window: &Self::Root,
         input: &mut Sender<Self::Input>,
         _output: &mut Sender<Self::Output>,
-    ) -> Fuselage<Self, Self::Widgets> {
+    ) -> ComponentParts<Self, Self::Widgets> {
         let model = AppModel { counter };
 
         let vbox = gtk::Box::builder()
@@ -74,7 +74,7 @@ impl SimpleComponent for AppModel {
 
         let widgets = AppWidgets { label };
 
-        Fuselage { model, widgets }
+        ComponentParts { model, widgets }
     }
 
     fn update(

--- a/src/app.rs
+++ b/src/app.rs
@@ -34,7 +34,7 @@ where
     /// Unlike [`gtk::Application::run`], this function
     /// does not handle command-line arguments. To pass arguments to GTK, use
     /// [`RelmApp::run_with_args`].
-    pub fn run(self, payload: C::Payload) {
+    pub fn run(self, payload: C::InitParams) {
         let RelmApp { bridge, app } = self;
         let controller = bridge.launch(payload).detach();
         let window = controller.widget().clone();
@@ -49,7 +49,7 @@ where
 
     /// Runs the application with the provided command-line arguments, returns once the application
     /// is closed.
-    pub fn run_with_args<S>(self, payload: C::Payload, args: &[S])
+    pub fn run_with_args<S>(self, payload: C::InitParams, args: &[S])
     where
         S: AsRef<str>,
     {

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,12 +2,12 @@ use gtk::prelude::{ApplicationExt, ApplicationExtManual, GtkApplicationExt, IsA,
 
 use crate::component::Component;
 use crate::component::ComponentController;
-use crate::Bridge;
+use crate::ComponentBuilder;
 
 /// An app that runs the main application.
 #[derive(Debug)]
 pub struct RelmApp<C: Component> {
-    bridge: Bridge<C, C::Root>,
+    bridge: ComponentBuilder<C, C::Root>,
 
     /// The [`gtk::Application`] that's used internally to setup
     /// and run the application.

--- a/src/component/builder/elm_like.rs
+++ b/src/component/builder/elm_like.rs
@@ -37,7 +37,7 @@ impl<C: Component> ComponentBuilder<C, C::Root> {
         // The main service receives `Self::Input` and `Self::CommandOutput` messages and applies
         // them to the model and view.
         let mut input_tx_ = input_tx.clone();
-        let fuselage_ = watcher.clone();
+        let watcher_ = watcher.clone();
         let id = crate::spawn_local(async move {
             loop {
                 let notifier = notifier.notified().fuse();
@@ -56,7 +56,7 @@ impl<C: Component> ComponentBuilder<C, C::Root> {
                             let &mut ComponentParts {
                                 ref mut model,
                                 ref mut widgets,
-                            } = &mut *fuselage_.state.borrow_mut();
+                            } = &mut *watcher_.state.borrow_mut();
 
                             if let Some(command) = model.update(message, &mut input_tx_, &mut output_tx)
                             {
@@ -78,7 +78,7 @@ impl<C: Component> ComponentBuilder<C, C::Root> {
                             let &mut ComponentParts {
                                 ref mut model,
                                 ref mut widgets,
-                            } = &mut *fuselage_.state.borrow_mut();
+                            } = &mut *watcher_.state.borrow_mut();
 
                             model.update_cmd(message, &mut input_tx_, &mut output_tx);
                             model.update_view(widgets, &mut input_tx_, &mut output_tx);
@@ -90,7 +90,7 @@ impl<C: Component> ComponentBuilder<C, C::Root> {
                         let &mut ComponentParts {
                             ref mut model,
                             ref mut widgets,
-                        } = &mut *fuselage_.state.borrow_mut();
+                        } = &mut *watcher_.state.borrow_mut();
 
                         model.update_view(widgets, &mut input_tx_, &mut output_tx);
                     }

--- a/src/component/builder/elm_like.rs
+++ b/src/component/builder/elm_like.rs
@@ -8,13 +8,13 @@ use futures::FutureExt;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-impl<C: Component> Bridge<C, C::Root> {
+impl<C: Component> ComponentBuilder<C, C::Root> {
     /// Starts the component, passing ownership to a future attached to a GLib context.
     pub fn launch(
         self,
         payload: C::Payload,
-    ) -> Fairing<C, C::Root, C::Widgets, C::Input, C::Output> {
-        let Bridge { root, .. } = self;
+    ) -> Connector<C, C::Root, C::Widgets, C::Input, C::Output> {
+        let ComponentBuilder { root, .. } = self;
 
         // Used for all events to be processed by this component's internal service.
         let (mut input_tx, mut input_rx) = mpsc::unbounded_channel::<C::Input>();
@@ -29,15 +29,15 @@ impl<C: Component> Bridge<C, C::Root> {
         let notifier = Rc::new(tokio::sync::Notify::new());
 
         // Constructs the initial model and view with the initial payload.
-        let fuselage = Rc::new(StateWatcher {
-            state: RefCell::new(C::dock(payload, &root, &mut input_tx, &mut output_tx)),
+        let watcher = Rc::new(StateWatcher {
+            state: RefCell::new(C::init_parts(payload, &root, &mut input_tx, &mut output_tx)),
             notifier: notifier.clone(),
         });
 
         // The main service receives `Self::Input` and `Self::CommandOutput` messages and applies
         // them to the model and view.
         let mut input_tx_ = input_tx.clone();
-        let fuselage_ = fuselage.clone();
+        let fuselage_ = watcher.clone();
         let id = crate::spawn_local(async move {
             loop {
                 let notifier = notifier.notified().fuse();
@@ -53,7 +53,7 @@ impl<C: Component> Bridge<C, C::Root> {
                     // Runs that command asynchronously in the background using tokio.
                     message = input => {
                         if let Some(message) = message {
-                            let &mut Fuselage {
+                            let &mut ComponentParts {
                                 ref mut model,
                                 ref mut widgets,
                             } = &mut *fuselage_.state.borrow_mut();
@@ -75,7 +75,7 @@ impl<C: Component> Bridge<C, C::Root> {
                     // Handles responses from a command.
                     message = cmd => {
                         if let Some(message) = message {
-                            let &mut Fuselage {
+                            let &mut ComponentParts {
                                 ref mut model,
                                 ref mut widgets,
                             } = &mut *fuselage_.state.borrow_mut();
@@ -87,7 +87,7 @@ impl<C: Component> Bridge<C, C::Root> {
 
                     // Triggered when the model and view have been updated externally.
                     _ = notifier => {
-                        let &mut Fuselage {
+                        let &mut ComponentParts {
                             ref mut model,
                             ref mut widgets,
                         } = &mut *fuselage_.state.borrow_mut();
@@ -102,8 +102,8 @@ impl<C: Component> Bridge<C, C::Root> {
         root.on_destroy(move || id.remove());
 
         // Give back a type for controlling the component service.
-        Fairing {
-            state: fuselage,
+        Connector {
+            state: watcher,
             widget: root,
             sender: input_tx,
             receiver: output_rx,

--- a/src/component/builder/elm_like.rs
+++ b/src/component/builder/elm_like.rs
@@ -12,7 +12,7 @@ impl<C: Component> ComponentBuilder<C, C::Root> {
     /// Starts the component, passing ownership to a future attached to a GLib context.
     pub fn launch(
         self,
-        payload: C::Payload,
+        payload: C::InitParams,
     ) -> Connector<C, C::Root, C::Widgets, C::Input, C::Output> {
         let ComponentBuilder { root, .. } = self;
 

--- a/src/component/builder/mod.rs
+++ b/src/component/builder/mod.rs
@@ -28,7 +28,7 @@ impl<Component, Root> ComponentBuilder<Component, Root> {
 
 impl<Component, Root: AsRef<gtk::Widget>> ComponentBuilder<Component, Root> {
     /// Attach the component's root widget to a given container.
-    pub fn attach_root(self, container: &impl RelmContainerExt) -> Self {
+    pub fn attach_to(self, container: &impl RelmContainerExt) -> Self {
         container.container_add(self.root.as_ref());
 
         self

--- a/src/component/builder/mod.rs
+++ b/src/component/builder/mod.rs
@@ -11,24 +11,24 @@ use tokio::sync::mpsc;
 
 /// A component that is ready for docking and launch.
 #[derive(Debug)]
-pub struct Bridge<Component, Root> {
+pub struct ComponentBuilder<Component, Root> {
     /// The root widget of the component.
     pub root: Root,
 
     pub(super) component: PhantomData<Component>,
 }
 
-impl<Component, Root> Bridge<Component, Root> {
+impl<Component, Root> ComponentBuilder<Component, Root> {
     /// Configure the root widget before launching.
-    pub fn preflight<F: FnOnce(&mut Root) + 'static>(mut self, func: F) -> Self {
+    pub fn update_root<F: FnOnce(&mut Root) + 'static>(mut self, func: F) -> Self {
         func(&mut self.root);
         self
     }
 }
 
-impl<Component, Root: AsRef<gtk::Widget>> Bridge<Component, Root> {
+impl<Component, Root: AsRef<gtk::Widget>> ComponentBuilder<Component, Root> {
     /// Attach the component's root widget to a given container.
-    pub fn attach_to(self, container: &impl RelmContainerExt) -> Self {
+    pub fn attach_root(self, container: &impl RelmContainerExt) -> Self {
         container.container_add(self.root.as_ref());
 
         self

--- a/src/component/builder/stateful.rs
+++ b/src/component/builder/stateful.rs
@@ -37,7 +37,7 @@ impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
         // The main service receives `Self::Input` and `Self::CommandOutput` messages and applies
         // them to the model and view.
         let mut input_tx_ = input_tx.clone();
-        let fuselage_ = watcher.clone();
+        let watcher_ = watcher.clone();
         let id = crate::spawn_local(async move {
             loop {
                 let notifier = notifier.notified().fuse();
@@ -56,7 +56,7 @@ impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
                             let &mut ComponentParts {
                                 ref mut model,
                                 ref mut widgets,
-                            } = &mut *fuselage_.state.borrow_mut();
+                            } = &mut *watcher_.state.borrow_mut();
 
                             if let Some(command) =
                                 model.update(widgets, message, &mut input_tx_, &mut output_tx)
@@ -77,7 +77,7 @@ impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
                             let &mut ComponentParts {
                                 ref mut model,
                                 ref mut widgets,
-                            } = &mut *fuselage_.state.borrow_mut();
+                            } = &mut *watcher_.state.borrow_mut();
 
                             model.update_cmd(widgets, message, &mut input_tx_, &mut output_tx);
                         }
@@ -88,7 +88,7 @@ impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
                         let &mut ComponentParts {
                             ref mut model,
                             ref mut widgets,
-                        } = &mut *fuselage_.state.borrow_mut();
+                        } = &mut *watcher_.state.borrow_mut();
 
                         model.update_notify(widgets, &mut input_tx_, &mut output_tx);
                     }

--- a/src/component/builder/stateful.rs
+++ b/src/component/builder/stateful.rs
@@ -12,7 +12,7 @@ impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
     /// Starts the component, passing ownership to a future attached to a GLib context.
     pub fn launch_stateful(
         self,
-        payload: C::Payload,
+        payload: C::InitParams,
     ) -> Connector<C, C::Root, C::Widgets, C::Input, C::Output> {
         let ComponentBuilder { root, .. } = self;
 

--- a/src/component/builder/stateful.rs
+++ b/src/component/builder/stateful.rs
@@ -8,13 +8,13 @@ use futures::FutureExt;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-impl<C: StatefulComponent> Bridge<C, C::Root> {
+impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
     /// Starts the component, passing ownership to a future attached to a GLib context.
     pub fn launch_stateful(
         self,
         payload: C::Payload,
-    ) -> Fairing<C, C::Root, C::Widgets, C::Input, C::Output> {
-        let Bridge { root, .. } = self;
+    ) -> Connector<C, C::Root, C::Widgets, C::Input, C::Output> {
+        let ComponentBuilder { root, .. } = self;
 
         // Used for all events to be processed by this component's internal service.
         let (mut input_tx, mut input_rx) = mpsc::unbounded_channel::<C::Input>();
@@ -29,15 +29,15 @@ impl<C: StatefulComponent> Bridge<C, C::Root> {
         let notifier = Rc::new(tokio::sync::Notify::new());
 
         // Constructs the initial model and view with the initial payload.
-        let fuselage = Rc::new(StateWatcher {
-            state: RefCell::new(C::dock(payload, &root, &mut input_tx, &mut output_tx)),
+        let watcher = Rc::new(StateWatcher {
+            state: RefCell::new(C::init_parts(payload, &root, &mut input_tx, &mut output_tx)),
             notifier: notifier.clone(),
         });
 
         // The main service receives `Self::Input` and `Self::CommandOutput` messages and applies
         // them to the model and view.
         let mut input_tx_ = input_tx.clone();
-        let fuselage_ = fuselage.clone();
+        let fuselage_ = watcher.clone();
         let id = crate::spawn_local(async move {
             loop {
                 let notifier = notifier.notified().fuse();
@@ -53,7 +53,7 @@ impl<C: StatefulComponent> Bridge<C, C::Root> {
                     // Runs that command asynchronously in the background using tokio.
                     message = input => {
                         if let Some(message) = message {
-                            let &mut Fuselage {
+                            let &mut ComponentParts {
                                 ref mut model,
                                 ref mut widgets,
                             } = &mut *fuselage_.state.borrow_mut();
@@ -74,7 +74,7 @@ impl<C: StatefulComponent> Bridge<C, C::Root> {
                     // Handles responses from a command.
                     message = cmd => {
                         if let Some(message) = message {
-                            let &mut Fuselage {
+                            let &mut ComponentParts {
                                 ref mut model,
                                 ref mut widgets,
                             } = &mut *fuselage_.state.borrow_mut();
@@ -85,7 +85,7 @@ impl<C: StatefulComponent> Bridge<C, C::Root> {
 
                     // Triggered when the model and view have been updated externally.
                     _ = notifier => {
-                        let &mut Fuselage {
+                        let &mut ComponentParts {
                             ref mut model,
                             ref mut widgets,
                         } = &mut *fuselage_.state.borrow_mut();
@@ -100,8 +100,8 @@ impl<C: StatefulComponent> Bridge<C, C::Root> {
         root.on_destroy(move || id.remove());
 
         // Give back a type for controlling the component service.
-        Fairing {
-            state: fuselage,
+        Connector {
+            state: watcher,
             widget: root,
             sender: input_tx,
             receiver: output_rx,

--- a/src/component/connector.rs
+++ b/src/component/connector.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 /// Contains the post-launch input sender and output receivers with the root widget.
 ///
 /// The receiver can be separated from the `Fairing` by choosing a method for handling it.
-pub struct Fairing<Component, Root, Widgets, Input, Output> {
+pub struct Connector<Component, Root, Widgets, Input, Output> {
     /// The models and widgets maintained by the component.
     pub(super) state: Rc<StateWatcher<Component, Widgets>>,
 
@@ -25,7 +25,7 @@ pub struct Fairing<Component, Root, Widgets, Input, Output> {
 }
 
 impl<Component, Root, Widgets, Input: 'static, Output: 'static>
-    Fairing<Component, Root, Widgets, Input, Output>
+    Connector<Component, Root, Widgets, Input, Output>
 {
     /// Forwards output events to the designated sender.
     pub fn forward<X: 'static, F: (Fn(Output) -> X) + 'static>(
@@ -33,7 +33,7 @@ impl<Component, Root, Widgets, Input: 'static, Output: 'static>
         sender_: Sender<X>,
         transform: F,
     ) -> Controller<Component, Root, Widgets, Input> {
-        let Fairing {
+        let Connector {
             state,
             widget,
             sender,
@@ -54,7 +54,7 @@ impl<Component, Root, Widgets, Input: 'static, Output: 'static>
         self,
         mut func: F,
     ) -> Controller<Component, Root, Widgets, Input> {
-        let Fairing {
+        let Connector {
             state,
             widget,
             sender,
@@ -92,7 +92,9 @@ impl<Component, Root, Widgets, Input: 'static, Output: 'static>
     }
 }
 
-impl<C: Component> ComponentController<C> for Fairing<C, C::Root, C::Widgets, C::Input, C::Output> {
+impl<C: Component> ComponentController<C>
+    for Connector<C, C::Root, C::Widgets, C::Input, C::Output>
+{
     fn sender(&self) -> &Sender<C::Input> {
         &self.sender
     }

--- a/src/component/elm_like.rs
+++ b/src/component/elm_like.rs
@@ -21,7 +21,7 @@ pub trait Component: Sized + 'static {
     type Output: 'static;
 
     /// The initial parameter(s) for launch.
-    type Payload;
+    type InitParams;
 
     /// The widget that was constructed by the component.
     type Root: OnDestroy;
@@ -42,7 +42,7 @@ pub trait Component: Sized + 'static {
 
     /// Creates the initial model and view, docking it into the component.
     fn init_parts(
-        params: Self::Payload,
+        params: Self::InitParams,
         root: &Self::Root,
         input: &mut Sender<Self::Input>,
         output: &mut Sender<Self::Output>,
@@ -95,7 +95,7 @@ pub trait SimpleComponent: Sized + 'static {
     type Output: 'static;
 
     /// The initial parameter(s) for launch.
-    type Payload;
+    type InitParams;
 
     /// The widget that was constructed by the component.
     type Root: OnDestroy;
@@ -116,7 +116,7 @@ pub trait SimpleComponent: Sized + 'static {
 
     /// Creates the initial model and view, docking it into the component.
     fn init_parts(
-        params: Self::Payload,
+        params: Self::InitParams,
         root: &Self::Root,
         input: &mut Sender<Self::Input>,
         output: &mut Sender<Self::Output>,
@@ -151,7 +151,7 @@ impl<C> Component for C
 where
     C: SimpleComponent,
 {
-    type Payload = C::Payload;
+    type InitParams = C::InitParams;
     type Input = C::Input;
     type Output = C::Output;
     type Root = C::Root;
@@ -165,7 +165,7 @@ where
     }
 
     fn init_parts(
-        params: Self::Payload,
+        params: Self::InitParams,
         root: &Self::Root,
         input: &mut Sender<Self::Input>,
         output: &mut Sender<Self::Output>,

--- a/src/component/elm_like.rs
+++ b/src/component/elm_like.rs
@@ -33,20 +33,20 @@ pub trait Component: Sized + 'static {
     fn init_root() -> Self::Root;
 
     /// Initializes the root widget and prepares a `Bridge` for docking.
-    fn init() -> Bridge<Self, Self::Root> {
-        Bridge {
+    fn init() -> ComponentBuilder<Self, Self::Root> {
+        ComponentBuilder {
             root: Self::init_root(),
             component: PhantomData,
         }
     }
 
     /// Creates the initial model and view, docking it into the component.
-    fn dock(
+    fn init_parts(
         params: Self::Payload,
         root: &Self::Root,
         input: &mut Sender<Self::Input>,
         output: &mut Sender<Self::Output>,
-    ) -> Fuselage<Self, Self::Widgets>;
+    ) -> ComponentParts<Self, Self::Widgets>;
 
     /// Processes inputs received by the component.
     #[allow(unused)]
@@ -107,20 +107,20 @@ pub trait SimpleComponent: Sized + 'static {
     fn init_root() -> Self::Root;
 
     /// Initializes the root widget and prepares a `Bridge` for docking.
-    fn init() -> Bridge<Self, Self::Root> {
-        Bridge {
+    fn init() -> ComponentBuilder<Self, Self::Root> {
+        ComponentBuilder {
             root: Self::init_root(),
             component: PhantomData,
         }
     }
 
     /// Creates the initial model and view, docking it into the component.
-    fn dock(
+    fn init_parts(
         params: Self::Payload,
         root: &Self::Root,
         input: &mut Sender<Self::Input>,
         output: &mut Sender<Self::Output>,
-    ) -> Fuselage<Self, Self::Widgets>;
+    ) -> ComponentParts<Self, Self::Widgets>;
 
     /// Processes inputs received by the component.
     #[allow(unused)]
@@ -164,13 +164,13 @@ where
         C::init_root()
     }
 
-    fn dock(
+    fn init_parts(
         params: Self::Payload,
         root: &Self::Root,
         input: &mut Sender<Self::Input>,
         output: &mut Sender<Self::Output>,
-    ) -> Fuselage<Self, Self::Widgets> {
-        C::dock(params, root, input, output)
+    ) -> ComponentParts<Self, Self::Widgets> {
+        C::init_parts(params, root, input, output)
     }
 
     fn update(

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -2,23 +2,23 @@
 // Copyright 2022 System76 <info@system76.com>
 // SPDX-License-Identifier: MIT or Apache-2.0
 
-mod bridge;
+mod builder;
+mod connector;
 mod controller;
 mod elm_like;
-mod fairing;
 mod state_watcher;
 mod stateful;
 
 #[allow(unreachable_pub)]
-pub use self::bridge::Bridge;
+pub use self::builder::ComponentBuilder;
+#[allow(unreachable_pub)]
+pub use self::connector::Connector;
 #[allow(unreachable_pub)]
 pub use self::controller::{ComponentController, Controller};
 #[allow(unreachable_pub)]
 pub use self::elm_like::Component;
 #[allow(unreachable_pub)]
 pub use self::elm_like::SimpleComponent;
-#[allow(unreachable_pub)]
-pub use self::fairing::Fairing;
 #[allow(unreachable_pub)]
 pub use self::state_watcher::StateWatcher;
 #[allow(unreachable_pub)]
@@ -32,7 +32,7 @@ pub type CommandFuture<T> = Pin<Box<dyn Future<Output = Option<T>> + Send>>;
 
 /// Contains the initial model and widgets being docked into a component.
 #[derive(Debug)]
-pub struct Fuselage<Model, Widgets> {
+pub struct ComponentParts<Model, Widgets> {
     /// The model of the component.
     pub model: Model,
     /// The widgets created for the view.

--- a/src/component/state_watcher.rs
+++ b/src/component/state_watcher.rs
@@ -1,4 +1,4 @@
-use super::Fuselage;
+use super::ComponentParts;
 use std::cell::{Ref, RefCell, RefMut};
 use std::rc::Rc;
 use tokio::sync::Notify;
@@ -9,18 +9,18 @@ use tokio::sync::Notify;
 #[derive(Debug)]
 pub struct StateWatcher<Component, Widgets> {
     /// The models and widgets maintained by the component.
-    pub(super) state: RefCell<Fuselage<Component, Widgets>>,
+    pub(super) state: RefCell<ComponentParts<Component, Widgets>>,
     pub(super) notifier: Rc<Notify>,
 }
 
 impl<Component, Widgets> StateWatcher<Component, Widgets> {
     /// Borrows the model and view of a component.
-    pub fn get(&self) -> Ref<'_, Fuselage<Component, Widgets>> {
+    pub fn get(&self) -> Ref<'_, ComponentParts<Component, Widgets>> {
         self.state.borrow()
     }
 
     /// Borrows the model and view of a component, and notifies the component to check for updates.
-    pub fn get_mut(&self) -> RefMut<'_, Fuselage<Component, Widgets>> {
+    pub fn get_mut(&self) -> RefMut<'_, ComponentParts<Component, Widgets>> {
         self.notifier.notify_one();
         self.state.borrow_mut()
     }

--- a/src/component/stateful.rs
+++ b/src/component/stateful.rs
@@ -21,7 +21,7 @@ pub trait StatefulComponent: Sized + 'static {
     type Output: 'static;
 
     /// The initial parameter(s) for launch.
-    type Payload;
+    type InitParams;
 
     /// The widget that was constructed by the component.
     type Root: OnDestroy;
@@ -42,7 +42,7 @@ pub trait StatefulComponent: Sized + 'static {
 
     /// Creates the initial model and view, docking it into the component.
     fn init_parts(
-        params: Self::Payload,
+        params: Self::InitParams,
         root: &Self::Root,
         input: &mut Sender<Self::Input>,
         output: &mut Sender<Self::Output>,

--- a/src/component/stateful.rs
+++ b/src/component/stateful.rs
@@ -33,20 +33,20 @@ pub trait StatefulComponent: Sized + 'static {
     fn init_root() -> Self::Root;
 
     /// Initializes the root widget and prepares a `Bridge` for docking.
-    fn init() -> Bridge<Self, Self::Root> {
-        Bridge {
+    fn init() -> ComponentBuilder<Self, Self::Root> {
+        ComponentBuilder {
             root: Self::init_root(),
             component: PhantomData,
         }
     }
 
     /// Creates the initial model and view, docking it into the component.
-    fn dock(
+    fn init_parts(
         params: Self::Payload,
         root: &Self::Root,
         input: &mut Sender<Self::Input>,
         output: &mut Sender<Self::Output>,
-    ) -> Fuselage<Self, Self::Widgets>;
+    ) -> ComponentParts<Self, Self::Widgets>;
 
     /// Processes inputs received by the component.
     #[allow(unused)]


### PR DESCRIPTION
Fixes #89 

## This is not final. Please comment if you have any suggestions!

---

### Summary of changes

| Old | New | Comment |
| - | - | - |
| **Types** |
| `Bridge` | `ComponentBuilder` |
| `Bridge::preflight` | `ComponentBuilder::update_root` |
| `Fuselage` | `ComponentParts` | I think it's nice to keep the struct because tuples are a bit weird to index and there is an API for accessing `ComponentParts`, similar to micro components |
| `Fairing` | `Connector` | Since connecting stuff is the main purpose of this type, I think this name makes sense |
| **Component trait** |
| `Component::dock` | `Component::init_parts` |
| `Payload` | `InitParams` | I like payload regardless of the analogy, but init params is still more expressive |