### PR TITLE
0.5: Graceful Shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
 [dependencies]
 adw = { version = "0.1", optional = true, package = "libadwaita" }
 async-broadcast = "0.3.4"
+flume = "0.10.11"
 fragile = "1.1.0"
 futures = "0.3.19"
 gtk = { version = "0.4.1", package = "gtk4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 
 [dependencies]
 adw = { version = "0.1", optional = true, package = "libadwaita" }
-blocking = "1.1.0"
+async-broadcast = "0.3.4"
 fragile = "1.1.0"
 futures = "0.3.19"
 gtk = { version = "0.4.1", package = "gtk4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
 [dependencies]
 adw = { version = "0.1", optional = true, package = "libadwaita" }
 async-broadcast = "0.3.4"
+async-oneshot = "0.5.0"
 flume = "0.10.11"
 fragile = "1.1.0"
 futures = "0.3.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ futures = "0.3.19"
 gtk = { version = "0.4.1", package = "gtk4" }
 log = "0.4.14"
 once_cell = "1.8"
-tokio = { version = "1.15", features = ["rt", "rt-multi-thread", "sync"] }
+tokio = { version = "1.15", features = ["rt", "rt-multi-thread"] }
 
 #relm4-macros = { version = "0.4.1", optional = true }
 relm4-macros = { path = "relm4-macros", optional = true }

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -105,7 +105,7 @@ impl Component for App {
                 append: button = &gtk::Button {
                     set_label: "Compute",
                     connect_clicked(input) => move |_| {
-                        let _ = input.send(Input::Compute);
+                        input.send(Input::Compute);
                     }
                 }
             }
@@ -186,12 +186,12 @@ impl Component for App {
                 let mut progress = 0.0;
 
                 while progress < 1.0 {
-                    let _ = out.send(CmdOut::Progress(progress));
+                    out.send(CmdOut::Progress(progress));
                     progress += 0.1;
                     tokio::time::sleep(std::time::Duration::from_millis(333)).await;
                 }
 
-                let _ = out.send(CmdOut::Finished(Ok("42".into())));
+                out.send(CmdOut::Finished(Ok("42".into())));
             })
             // Perform task until a shutdown interrupts it
             .drop_on_shutdown()

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -194,7 +194,7 @@ impl Component for App {
                 let _ = out.send(CmdOut::Finished(Ok("42".into())));
             })
             // Perform task until a shutdown interrupts it
-            .wait_then_drop()
+            .drop_on_shutdown()
             // Wrap into a `Pin<Box<Future>>` for return
             .boxed()
     }

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -1,0 +1,201 @@
+// Copyright 2022 System76 <info@system76.com>
+// SPDX-License-Identifier: MIT or Apache-2.0
+
+//! A component which allows the caller to define what options ae in its list.
+//!
+//! On init of the view, an output is sent to the caller to request to load widgets.
+//!
+//! Clicking a button will open the webpage to that option.
+//!
+//! Clicking the clear button will clear the list box and send a command to the
+//! background that waits 2 seconds before issuing a reload command back to the
+//! component, which forwards the reload command back to the caller of the
+//! component, which then issues to reload the widgets again.
+
+use futures::FutureExt;
+use gtk::prelude::*;
+use relm4::*;
+
+fn main() {
+    RelmApp::<App>::new("org.relm4.ProgressExample").run("Settings List Demo".into());
+}
+
+#[derive(Default)]
+pub struct App {
+    /// Tracks progress status
+    computing: bool,
+
+    /// Contains output of a completed task.
+    task: Option<CmdOut>,
+}
+
+pub struct Widgets {
+    button: gtk::Button,
+    label: gtk::Label,
+    progress: gtk::ProgressBar,
+}
+
+pub enum Input {
+    Compute,
+}
+
+pub enum Output {
+    Clicked(u32),
+}
+
+pub enum Command {
+    /// Initiate a background job which pushes the progress bar.
+    Compute,
+}
+
+pub enum CmdOut {
+    /// Progress update from a command.
+    Progress(f32),
+    /// The final output of the command.
+    Finished(Result<String, ()>),
+}
+
+impl Component for App {
+    type Command = Command;
+    type CommandOutput = CmdOut;
+    type Input = Input;
+    type Output = Output;
+    type InitParams = String;
+    type Root = gtk::Window;
+    type Widgets = Widgets;
+
+    fn init_root() -> Self::Root {
+        gtk::Window::default()
+    }
+
+    fn init_parts(
+        _args: Self::InitParams,
+        root: &Self::Root,
+        input: &mut Sender<Self::Input>,
+        _output: &mut Sender<Self::Output>,
+    ) -> ComponentParts<Self, Self::Widgets> {
+        relm4_macros::view! {
+            container = gtk::Box {
+                set_halign: gtk::Align::Center,
+                set_valign: gtk::Align::Center,
+                set_width_request: 300,
+                set_spacing: 12,
+                set_margin_top: 4,
+                set_margin_bottom: 4,
+                set_margin_start: 12,
+                set_margin_end: 12,
+                set_orientation: gtk::Orientation::Horizontal,
+
+                &gtk::Box {
+                    set_spacing: 4,
+                    set_hexpand: true,
+                    set_valign: gtk::Align::Center,
+                    set_orientation: gtk::Orientation::Vertical,
+
+                    append: label = &gtk::Label {
+                        set_xalign: 0.0,
+                        set_label: "Find the answer to life:",
+                    },
+
+                    append: progress = &gtk::ProgressBar {
+                        set_visible: false,
+                    },
+                },
+
+                append: button = &gtk::Button {
+                    set_label: "Compute",
+                    connect_clicked(input) => move |_| {
+                        let _ = input.send(Input::Compute);
+                    }
+                }
+            }
+        }
+
+        root.set_child(Some(&container));
+
+        ComponentParts {
+            model: App::default(),
+            widgets: Widgets {
+                label,
+                button,
+                progress,
+            },
+        }
+    }
+
+    fn update(
+        &mut self,
+        message: Self::Input,
+        _input: &mut Sender<Self::Input>,
+        _output: &mut Sender<Self::Output>,
+    ) -> Option<Self::Command> {
+        match message {
+            Input::Compute => {
+                self.computing = true;
+                return Some(Command::Compute);
+            }
+        }
+    }
+
+    fn update_cmd(
+        &mut self,
+        message: Self::CommandOutput,
+        _input: &mut Sender<Self::Input>,
+        _output: &mut Sender<Self::Output>,
+    ) {
+        if let CmdOut::Finished(_) = message {
+            self.computing = false;
+        }
+
+        self.task = Some(message);
+    }
+
+    fn update_view(
+        &self,
+        widgets: &mut Self::Widgets,
+        _input: &mut Sender<Self::Input>,
+        _output: &mut Sender<Self::Output>,
+    ) {
+        widgets.button.set_sensitive(!self.computing);
+
+        if let Some(ref progress) = self.task {
+            match progress {
+                CmdOut::Progress(p) => {
+                    widgets.label.set_label("Searching for the answer...");
+                    widgets.progress.show();
+                    widgets.progress.set_fraction(*p as f64);
+                }
+                CmdOut::Finished(result) => {
+                    widgets.progress.hide();
+                    widgets
+                        .label
+                        .set_label(&format!("The answer to life is: {:?}", result));
+                }
+            }
+        }
+    }
+
+    fn command(
+        _message: Self::Command,
+        shutdown: ShutdownReceiver,
+        out: Sender<CmdOut>,
+    ) -> CommandFuture {
+        shutdown
+            // Performs this operation until a shutdown is triggered
+            .register(async move {
+                let mut progress = 0.0;
+
+                while progress < 1.0 {
+                    let _ = out.send(CmdOut::Progress(progress));
+                    progress += 0.1;
+                    tokio::time::sleep(std::time::Duration::from_millis(333)).await;
+                }
+
+                let _ = out.send(CmdOut::Finished(Ok("42".into())));
+            })
+            // Perform task until a shutdown interrupts it
+            .wait_then_drop()
+            // Wrap into a `Pin<Box<Future>>` for return
+            .boxed()
+    }
+}

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -71,8 +71,8 @@ impl Component for App {
     fn init_parts(
         _args: Self::InitParams,
         root: &Self::Root,
-        input: &mut Sender<Self::Input>,
-        _output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        _output: &Sender<Self::Output>,
     ) -> ComponentParts<Self, Self::Widgets> {
         relm4_macros::view! {
             container = gtk::Box {
@@ -126,8 +126,8 @@ impl Component for App {
     fn update(
         &mut self,
         message: Self::Input,
-        _input: &mut Sender<Self::Input>,
-        _output: &mut Sender<Self::Output>,
+        _input: &Sender<Self::Input>,
+        _output: &Sender<Self::Output>,
     ) -> Option<Self::Command> {
         match message {
             Input::Compute => {
@@ -140,8 +140,8 @@ impl Component for App {
     fn update_cmd(
         &mut self,
         message: Self::CommandOutput,
-        _input: &mut Sender<Self::Input>,
-        _output: &mut Sender<Self::Output>,
+        _input: &Sender<Self::Input>,
+        _output: &Sender<Self::Output>,
     ) {
         if let CmdOut::Finished(_) = message {
             self.computing = false;
@@ -153,8 +153,8 @@ impl Component for App {
     fn update_view(
         &self,
         widgets: &mut Self::Widgets,
-        _input: &mut Sender<Self::Input>,
-        _output: &mut Sender<Self::Output>,
+        _input: &Sender<Self::Input>,
+        _output: &Sender<Self::Output>,
     ) {
         widgets.button.set_sensitive(!self.computing);
 

--- a/examples/settings_list.rs
+++ b/examples/settings_list.rs
@@ -239,7 +239,11 @@ impl Component for App {
         }
     }
 
-    fn command(message: Self::Command, shutdown: ShutdownReceiver, out: Sender<CmdOut>) -> CommandFuture {
+    fn command(
+        message: Self::Command,
+        shutdown: ShutdownReceiver,
+        out: Sender<CmdOut>,
+    ) -> CommandFuture {
         shutdown
             // Performs this operation until a shutdown is triggered
             .register(async move {
@@ -251,9 +255,7 @@ impl Component for App {
                 }
             })
             // Perform task until a shutdown interrupts it
-            .wait()
-            // Drop output
-            .map(|_| ())
+            .wait_then_drop()
             // Wrap into a `Pin<Box<Future>>` for return
             .boxed()
     }

--- a/examples/settings_list.rs
+++ b/examples/settings_list.rs
@@ -122,8 +122,8 @@ impl Component for App {
     fn init_parts(
         title: Self::InitParams,
         root: &Self::Root,
-        _input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        _input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) -> ComponentParts<Self, Self::Widgets> {
         // Request the caller to reload its options.
         let _ = output.send(Output::Reload);
@@ -156,8 +156,8 @@ impl Component for App {
     fn update(
         &mut self,
         message: Self::Input,
-        _input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        _input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) -> Option<Self::Command> {
         match message {
             Input::AddSetting {
@@ -184,8 +184,8 @@ impl Component for App {
     fn update_cmd(
         &mut self,
         message: Self::CommandOutput,
-        _input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        _input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) {
         match message {
             CmdOut::Reload => {
@@ -197,8 +197,8 @@ impl Component for App {
     fn update_view(
         &self,
         widgets: &mut Self::Widgets,
-        _input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        _input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) {
         if self.options.is_empty() && !widgets.options.is_empty() {
             widgets.list.remove_all();

--- a/examples/settings_list.rs
+++ b/examples/settings_list.rs
@@ -255,7 +255,7 @@ impl Component for App {
                 }
             })
             // Perform task until a shutdown interrupts it
-            .wait_then_drop()
+            .drop_on_shutdown()
             // Wrap into a `Pin<Box<Future>>` for return
             .boxed()
     }

--- a/examples/settings_list.rs
+++ b/examples/settings_list.rs
@@ -37,26 +37,26 @@ fn main() {
                                 xdg_open("https://aaronerhardt.github.io/docs/relm4/relm4/".into())
                             }
                             2 => {
-                                let _ = sender.send(Input::Clear);
+                                sender.send(Input::Clear);
                             }
                             _ => (),
                         }
                     }
 
                     Output::Reload => {
-                        let _ = sender.send(Input::AddSetting {
+                        sender.send(Input::AddSetting {
                             description: "Browse GitHub Repository".into(),
                             button: "GitHub".into(),
                             id: 0,
                         });
 
-                        let _ = sender.send(Input::AddSetting {
+                        sender.send(Input::AddSetting {
                             description: "Browse Documentation".into(),
                             button: "Docs".into(),
                             id: 1,
                         });
 
-                        let _ = sender.send(Input::AddSetting {
+                        sender.send(Input::AddSetting {
                             description: "Clear List".into(),
                             button: "Clear".into(),
                             id: 2,
@@ -126,7 +126,7 @@ impl Component for App {
         output: &Sender<Self::Output>,
     ) -> ComponentParts<Self, Self::Widgets> {
         // Request the caller to reload its options.
-        let _ = output.send(Output::Reload);
+        output.send(Output::Reload);
 
         let label = gtk::builders::LabelBuilder::new()
             .label(&title)
@@ -174,7 +174,7 @@ impl Component for App {
             }
 
             Input::Reload => {
-                let _ = output.send(Output::Reload);
+                output.send(Output::Reload);
             }
         }
 
@@ -189,7 +189,7 @@ impl Component for App {
     ) {
         match message {
             CmdOut::Reload => {
-                let _ = output.send(Output::Reload);
+                output.send(Output::Reload);
             }
         }
     }
@@ -227,7 +227,7 @@ impl Component for App {
                             set_size_group: &widgets.button_sg,
 
                             connect_clicked(output) => move |_| {
-                                let _ = output.send(Output::Clicked(id));
+                                output.send(Output::Clicked(id));
                             }
                         }
                     }
@@ -250,7 +250,7 @@ impl Component for App {
                 match message {
                     Command::Reload => {
                         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                        let _ = out.send(CmdOut::Reload);
+                        out.send(CmdOut::Reload);
                     }
                 }
             })

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -58,8 +58,8 @@ impl SimpleComponent for AppModel {
     fn init_parts(
         counter: Self::InitParams,
         root: &Self::Root,
-        input: &mut Sender<Self::Input>,
-        _output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        _output: &Sender<Self::Output>,
     ) -> ComponentParts<Self, Self::Widgets> {
         let model = AppModel { counter };
 
@@ -72,8 +72,8 @@ impl SimpleComponent for AppModel {
     fn update(
         &mut self,
         msg: Self::Input,
-        _input: &mut Sender<Self::Input>,
-        _ouput: &mut Sender<Self::Output>,
+        _input: &Sender<Self::Input>,
+        _ouput: &Sender<Self::Output>,
     ) {
         match msg {
             AppMsg::Increment => {

--- a/examples/simple_manual.rs
+++ b/examples/simple_manual.rs
@@ -40,8 +40,8 @@ impl SimpleComponent for AppModel {
     fn init_parts(
         counter: Self::InitParams,
         window: &Self::Root,
-        input: &mut Sender<Self::Input>,
-        _output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        _output: &Sender<Self::Output>,
     ) -> ComponentParts<Self, Self::Widgets> {
         let model = AppModel { counter };
 
@@ -80,8 +80,8 @@ impl SimpleComponent for AppModel {
     fn update(
         &mut self,
         msg: Self::Input,
-        _input: &mut Sender<Self::Input>,
-        _ouput: &mut Sender<Self::Output>,
+        _input: &Sender<Self::Input>,
+        _ouput: &Sender<Self::Output>,
     ) {
         match msg {
             AppMsg::Increment => {
@@ -97,8 +97,8 @@ impl SimpleComponent for AppModel {
     fn update_view(
         &self,
         widgets: &mut Self::Widgets,
-        _input: &mut Sender<Self::Input>,
-        _output: &mut Sender<Self::Output>,
+        _input: &Sender<Self::Input>,
+        _output: &Sender<Self::Output>,
     ) {
         widgets
             .label

--- a/relm4-macros/src/component/mod.rs
+++ b/relm4-macros/src/component/mod.rs
@@ -146,8 +146,8 @@ pub(crate) fn generate_tokens(
             fn update_view(
                 &self,
                 widgets: &mut Self::Widgets,
-                input: &mut Sender<Self::Input>,
-                output: &mut Sender<Self::Output>,
+                input: &Sender<Self::Input>,
+                output: &Sender<Self::Output>,
             ) {
                 let model = self;
                 // Wrap pre_view and post_view code to prevent early returns from skipping other view code.

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,0 +1,39 @@
+// Copyright 2022 System76 <info@system76.com>
+// SPDX-License-Identifier: MIT or Apache-2.0
+
+use tokio::sync::mpsc;
+
+pub(crate) fn channel<T>() -> (Sender<T>, Receiver<T>) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    (Sender(tx), Receiver(rx))
+}
+
+/// A Relm4 sender sends messages to a component or worker.
+#[derive(Debug)]
+pub struct Sender<T>(pub(crate) mpsc::UnboundedSender<T>);
+
+impl<T> Sender<T> {
+    /// Sends messages to a component or worker.
+    pub fn send(&self, message: T) {
+        if self.0.send(message).is_err() {
+            panic!("receiver was dropped");
+        }
+    }
+}
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+/// A Relm4 receiver receives messages from a component or worker.
+#[derive(Debug)]
+pub struct Receiver<T>(pub(crate) mpsc::UnboundedReceiver<T>);
+
+impl<T> Receiver<T> {
+    /// Receives a message from a component or worker.
+    pub async fn recv(&mut self) -> Option<T> {
+        self.0.recv().await
+    }
+}

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -11,8 +11,8 @@ pub(crate) fn channel<T>() -> (Sender<T>, Receiver<T>) {
 pub struct Sender<T>(pub(crate) flume::Sender<T>);
 
 impl<T> From<flume::Sender<T>> for Sender<T> {
-    fn from(tokio: flume::Sender<T>) -> Self {
-        Self(tokio)
+    fn from(sender: flume::Sender<T>) -> Self {
+        Self(sender)
     }
 }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -12,6 +12,12 @@ pub(crate) fn channel<T>() -> (Sender<T>, Receiver<T>) {
 #[derive(Debug)]
 pub struct Sender<T>(pub(crate) mpsc::UnboundedSender<T>);
 
+impl<T> From<mpsc::UnboundedSender<T>> for Sender<T> {
+    fn from(tokio: mpsc::UnboundedSender<T>) -> Self {
+        Self(tokio)
+    }
+}
+
 impl<T> Sender<T> {
     /// Sends messages to a component or worker.
     pub fn send(&self, message: T) {
@@ -35,5 +41,22 @@ impl<T> Receiver<T> {
     /// Receives a message from a component or worker.
     pub async fn recv(&mut self) -> Option<T> {
         self.0.recv().await
+    }
+
+    /// Forwards an event from one channel to another.
+    pub async fn forward<Transformer, Output>(
+        mut self,
+        sender: impl Into<Sender<Output>>,
+        transformer: Transformer,
+    ) where
+        Transformer: (Fn(T) -> Output) + 'static,
+        Output: 'static,
+    {
+        let sender = sender.into();
+        while let Some(event) = self.recv().await {
+            if sender.0.send(transformer(event)).is_err() {
+                break;
+            }
+        }
     }
 }

--- a/src/component/builder/elm_like.rs
+++ b/src/component/builder/elm_like.rs
@@ -72,13 +72,8 @@ impl<C: Component> ComponentBuilder<C, C::Root> {
 
                             if let Some(command) = model.update(message, &mut input_tx_, &mut output_tx)
                             {
-                                let input = cmd_tx.clone();
                                 let recipient = death_recipient.clone();
-                                crate::spawn(async move {
-                                    if let Some(message) = C::command(command, recipient).await {
-                                        let _ = input.send(message);
-                                    }
-                                });
+                                crate::spawn(C::command(command, recipient, cmd_tx.clone()));
                             }
 
                             model.update_view(widgets, &mut input_tx_, &mut output_tx);

--- a/src/component/builder/elm_like.rs
+++ b/src/component/builder/elm_like.rs
@@ -4,11 +4,13 @@
 
 use super::super::*;
 use super::*;
+
 use crate::shutdown;
+
+use async_oneshot::oneshot;
 use futures::FutureExt;
 use std::cell::RefCell;
 use std::rc::Rc;
-use tokio::sync::oneshot;
 
 impl<C: Component> ComponentBuilder<C, C::Root> {
     /// Starts the component, passing ownership to a future attached to a GLib context.
@@ -38,7 +40,7 @@ impl<C: Component> ComponentBuilder<C, C::Root> {
 
         // The source ID of the component's service will be sent through this once the root
         // widget has been iced, which will give the component one last chance to say goodbye.
-        let (burn_notifier, burn_recipient) = oneshot::channel::<gtk::glib::SourceId>();
+        let (mut burn_notifier, burn_recipient) = oneshot::<gtk::glib::SourceId>();
 
         // Notifies the component's child commands that it is now deceased.
         let (death_notifier, death_recipient) = shutdown::channel();

--- a/src/component/builder/elm_like.rs
+++ b/src/component/builder/elm_like.rs
@@ -19,13 +19,13 @@ impl<C: Component> ComponentBuilder<C, C::Root> {
         let ComponentBuilder { root, .. } = self;
 
         // Used for all events to be processed by this component's internal service.
-        let (mut input_tx, mut input_rx) = mpsc::unbounded_channel::<C::Input>();
+        let (mut input_tx, mut input_rx) = crate::channel::<C::Input>();
 
         // Used by this component to send events to be handled externally by the caller.
-        let (mut output_tx, output_rx) = mpsc::unbounded_channel::<C::Output>();
+        let (mut output_tx, output_rx) = crate::channel::<C::Output>();
 
         // Sends messages from commands executed from the background.
-        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel::<C::CommandOutput>();
+        let (cmd_tx, mut cmd_rx) = crate::channel::<C::CommandOutput>();
 
         // Gets notifications when a component's model and view is updated externally.
         let notifier = Rc::new(tokio::sync::Notify::new());

--- a/src/component/builder/mod.rs
+++ b/src/component/builder/mod.rs
@@ -7,7 +7,6 @@ mod stateful;
 
 use crate::RelmContainerExt;
 use std::marker::PhantomData;
-use tokio::sync::mpsc;
 
 /// A component that is ready for docking and launch.
 #[derive(Debug)]

--- a/src/component/builder/stateful.rs
+++ b/src/component/builder/stateful.rs
@@ -5,10 +5,10 @@
 use super::super::*;
 use super::*;
 use crate::shutdown;
+use async_oneshot::oneshot;
 use futures::FutureExt;
 use std::cell::RefCell;
 use std::rc::Rc;
-use tokio::sync::oneshot;
 
 impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
     /// Starts the component, passing ownership to a future attached to a GLib context.
@@ -38,7 +38,7 @@ impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
 
         // The source ID of the component's service will be sent through this once the root
         // widget has been iced, which will give the component one last chance to say goodbye.
-        let (burn_notifier, burn_recipient) = oneshot::channel::<gtk::glib::SourceId>();
+        let (mut burn_notifier, burn_recipient) = oneshot::<gtk::glib::SourceId>();
 
         // Notifies the component's child commands that it is now deceased.
         let (death_notifier, death_recipient) = shutdown::channel();

--- a/src/component/builder/stateful.rs
+++ b/src/component/builder/stateful.rs
@@ -28,12 +28,12 @@ impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
         let (cmd_tx, mut cmd_rx) = crate::channel::<C::CommandOutput>();
 
         // Gets notifications when a component's model and view is updated externally.
-        let notifier = Rc::new(tokio::sync::Notify::new());
+        let (notifier, notifier_rx) = flume::bounded(0);
 
         // Constructs the initial model and view with the initial payload.
         let watcher = Rc::new(StateWatcher {
             state: RefCell::new(C::init_parts(payload, &root, &mut input_tx, &mut output_tx)),
-            notifier: notifier.clone(),
+            notifier,
         });
 
         // The source ID of the component's service will be sent through this once the root
@@ -52,7 +52,7 @@ impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
         let id = crate::spawn_local(async move {
             let mut burn_notice = burn_recipient.fuse();
             loop {
-                let notifier = notifier.notified().fuse();
+                let notifier = notifier_rx.recv_async().fuse();
                 let cmd = cmd_rx.recv().fuse();
                 let input = input_rx.recv().fuse();
 

--- a/src/component/builder/stateful.rs
+++ b/src/component/builder/stateful.rs
@@ -7,6 +7,7 @@ use super::*;
 use futures::FutureExt;
 use std::cell::RefCell;
 use std::rc::Rc;
+use tokio::sync::oneshot;
 
 impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
     /// Starts the component, passing ownership to a future attached to a GLib context.
@@ -34,11 +35,18 @@ impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
             notifier: notifier.clone(),
         });
 
-        // The main service receives `Self::Input` and `Self::CommandOutput` messages and applies
-        // them to the model and view.
+        // The source ID of the component's service will be sent through this once the root
+        // widget has been iced, which will give the component one last chance to say goodbye.
+        let (burn_notifier, burn_recipient) = oneshot::channel::<gtk::glib::SourceId>();
+
         let mut input_tx_ = input_tx.clone();
         let watcher_ = watcher.clone();
+
+        // Spawns the component's service. It will receive both `Self::Input` and
+        // `Self::CommandOutput` messages. It will spawn commands as requested by
+        // updates, and send `Self::Output` messages externally.
         let id = crate::spawn_local(async move {
+            let mut burn_notice = burn_recipient.fuse();
             loop {
                 let notifier = notifier.notified().fuse();
                 let cmd = cmd_rx.recv().fuse();
@@ -92,12 +100,31 @@ impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
 
                         model.update_notify(widgets, &mut input_tx_, &mut output_tx);
                     }
+
+                    // Triggered when the component is destroyed
+                    id = burn_notice => {
+                        let ComponentParts {
+                            ref mut model,
+                            ref mut widgets,
+                        } = &mut *watcher_.state.borrow_mut();
+
+                        model.shutdown(widgets, output_tx);
+
+                        if let Ok(id) = id {
+                            id.remove();
+                        }
+
+                        return
+                    }
                 );
             }
         });
 
         // When the root widget is destroyed, the spawned service will be removed.
-        root.on_destroy(move || id.remove());
+        // Passes the `glib::SourceId` through the shutdown channel.
+        root.on_destroy(move || {
+            let _ = burn_notifier.send(id);
+        });
 
         // Give back a type for controlling the component service.
         Connector {

--- a/src/component/builder/stateful.rs
+++ b/src/component/builder/stateful.rs
@@ -4,10 +4,11 @@
 
 use super::super::*;
 use super::*;
+use crate::shutdown;
 use futures::FutureExt;
 use std::cell::RefCell;
 use std::rc::Rc;
-use tokio::sync::{broadcast, oneshot};
+use tokio::sync::oneshot;
 
 impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
     /// Starts the component, passing ownership to a future attached to a GLib context.
@@ -40,7 +41,7 @@ impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
         let (burn_notifier, burn_recipient) = oneshot::channel::<gtk::glib::SourceId>();
 
         // Notifies the component's child commands that it is now deceased.
-        let (death_notifier, _) = broadcast::channel::<()>(1);
+        let (death_notifier, death_recipient) = shutdown::channel();
 
         let mut input_tx_ = input_tx.clone();
         let watcher_ = watcher.clone();
@@ -73,7 +74,7 @@ impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
                                 model.update(widgets, message, &mut input_tx_, &mut output_tx)
                             {
                                 let cmd_tx = cmd_tx.clone();
-                                let recipient = death_notifier.subscribe();
+                                let recipient = death_recipient.clone();
                                 crate::spawn(async move {
                                     if let Some(output) = C::command(command, recipient).await {
                                         let _ = cmd_tx.send(output);
@@ -114,7 +115,7 @@ impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
 
                         model.shutdown(widgets, output_tx);
 
-                        let _ = death_notifier.send(());
+                        let _ = death_notifier.shutdown();
 
                         if let Ok(id) = id {
                             id.remove();

--- a/src/component/builder/stateful.rs
+++ b/src/component/builder/stateful.rs
@@ -19,13 +19,13 @@ impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
         let ComponentBuilder { root, .. } = self;
 
         // Used for all events to be processed by this component's internal service.
-        let (mut input_tx, mut input_rx) = mpsc::unbounded_channel::<C::Input>();
+        let (mut input_tx, mut input_rx) = crate::channel::<C::Input>();
 
         // Used by this component to send events to be handled externally by the caller.
-        let (mut output_tx, output_rx) = mpsc::unbounded_channel::<C::Output>();
+        let (mut output_tx, output_rx) = crate::channel::<C::Output>();
 
         // Sends messages from commands executed from the background.
-        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel::<C::CommandOutput>();
+        let (cmd_tx, mut cmd_rx) = crate::channel::<C::CommandOutput>();
 
         // Gets notifications when a component's model and view is updated externally.
         let notifier = Rc::new(tokio::sync::Notify::new());

--- a/src/component/builder/stateful.rs
+++ b/src/component/builder/stateful.rs
@@ -75,11 +75,7 @@ impl<C: StatefulComponent> ComponentBuilder<C, C::Root> {
                             {
                                 let cmd_tx = cmd_tx.clone();
                                 let recipient = death_recipient.clone();
-                                crate::spawn(async move {
-                                    if let Some(output) = C::command(command, recipient).await {
-                                        let _ = cmd_tx.send(output);
-                                    }
-                                });
+                                crate::spawn(C::command(command, recipient, cmd_tx));
                             }
                         }
                     }

--- a/src/component/connector.rs
+++ b/src/component/connector.rs
@@ -40,7 +40,7 @@ impl<Component, Root, Widgets, Input: 'static, Output: 'static>
             receiver,
         } = self;
 
-        crate::spawn_local(crate::forward(receiver, sender_, transform));
+        crate::spawn_local(receiver.forward(sender_, transform));
 
         Controller {
             state,

--- a/src/component/controller.rs
+++ b/src/component/controller.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 /// Shared behavior of component controller types.
 pub trait ComponentController<C: Component> {
     /// Emits an input to the component.
-    fn emit(&mut self, event: C::Input) {
+    fn emit(&self, event: C::Input) {
         let _ = self.sender().send(event);
     }
 

--- a/src/component/elm_like.rs
+++ b/src/component/elm_like.rs
@@ -84,6 +84,10 @@ pub trait Component: Sized + 'static {
     fn command(message: Self::Command) -> CommandFuture<Self::CommandOutput> {
         Box::pin(async move { None })
     }
+
+    /// Last method called before a component is shut down.
+    #[allow(unused)]
+    fn shutdown(&mut self, widgets: &mut Self::Widgets, output: Sender<Self::Output>) {}
 }
 
 /// Elm-style variant of a Component with view updates separated from input updates
@@ -145,6 +149,10 @@ pub trait SimpleComponent: Sized + 'static {
         output: &mut Sender<Self::Output>,
     ) {
     }
+
+    /// Last method called before a component is shut down.
+    #[allow(unused)]
+    fn shutdown(&mut self, widgets: &mut Self::Widgets, output: Sender<Self::Output>) {}
 }
 
 impl<C> Component for C
@@ -190,5 +198,9 @@ where
         output: &mut Sender<Self::Output>,
     ) {
         C::update_view(self, widgets, input, output)
+    }
+
+    fn shutdown(&mut self, widgets: &mut Self::Widgets, output: Sender<Self::Output>) {
+        self.shutdown(widgets, output);
     }
 }

--- a/src/component/elm_like.rs
+++ b/src/component/elm_like.rs
@@ -84,8 +84,9 @@ pub trait Component: Sized + 'static {
     fn command(
         message: Self::Command,
         shutdown: ShutdownReceiver,
-    ) -> CommandFuture<Self::CommandOutput> {
-        Box::pin(async move { None })
+        output: Sender<Self::CommandOutput>,
+    ) -> CommandFuture {
+        Box::pin(async {})
     }
 
     /// Last method called before a component is shut down.

--- a/src/component/elm_like.rs
+++ b/src/component/elm_like.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 
 use super::*;
-use crate::Sender;
+use crate::{Sender, ShutdownReceiver};
 use std::marker::PhantomData;
 
 /// Elm-style variant of a Component with view updates separated from input updates
@@ -81,7 +81,10 @@ pub trait Component: Sized + 'static {
 
     /// A command to perform in a background thread.
     #[allow(unused)]
-    fn command(message: Self::Command) -> CommandFuture<Self::CommandOutput> {
+    fn command(
+        message: Self::Command,
+        shutdown: ShutdownReceiver,
+    ) -> CommandFuture<Self::CommandOutput> {
         Box::pin(async move { None })
     }
 

--- a/src/component/elm_like.rs
+++ b/src/component/elm_like.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 
 use super::*;
-use crate::{Sender, ShutdownReceiver};
+use crate::{shutdown::ShutdownReceiver, Sender};
 use std::marker::PhantomData;
 
 /// Elm-style variant of a Component with view updates separated from input updates

--- a/src/component/elm_like.rs
+++ b/src/component/elm_like.rs
@@ -44,8 +44,8 @@ pub trait Component: Sized + 'static {
     fn init_parts(
         params: Self::InitParams,
         root: &Self::Root,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) -> ComponentParts<Self, Self::Widgets>;
 
     /// Processes inputs received by the component.
@@ -53,8 +53,8 @@ pub trait Component: Sized + 'static {
     fn update(
         &mut self,
         message: Self::Input,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) -> Option<Self::Command> {
         None
     }
@@ -64,8 +64,8 @@ pub trait Component: Sized + 'static {
     fn update_cmd(
         &mut self,
         message: Self::CommandOutput,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) {
     }
 
@@ -74,8 +74,8 @@ pub trait Component: Sized + 'static {
     fn update_view(
         &self,
         widgets: &mut Self::Widgets,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) {
     }
 
@@ -126,8 +126,8 @@ pub trait SimpleComponent: Sized + 'static {
     fn init_parts(
         params: Self::InitParams,
         root: &Self::Root,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) -> ComponentParts<Self, Self::Widgets>;
 
     /// Processes inputs received by the component.
@@ -135,22 +135,22 @@ pub trait SimpleComponent: Sized + 'static {
     fn update(
         &mut self,
         message: Self::Input,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) {
     }
 
     /// Defines how the component should respond to command updates.
     #[allow(unused)]
-    fn update_cmd(&mut self, input: &mut Sender<Self::Input>, output: &mut Sender<Self::Output>) {}
+    fn update_cmd(&mut self, input: &Sender<Self::Input>, output: &Sender<Self::Output>) {}
 
     /// Updates the view after the model has been updated.
     #[allow(unused)]
     fn update_view(
         &self,
         widgets: &mut Self::Widgets,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) {
     }
 
@@ -179,8 +179,8 @@ where
     fn init_parts(
         params: Self::InitParams,
         root: &Self::Root,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) -> ComponentParts<Self, Self::Widgets> {
         C::init_parts(params, root, input, output)
     }
@@ -188,8 +188,8 @@ where
     fn update(
         &mut self,
         message: Self::Input,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) -> Option<Self::Command> {
         C::update(self, message, input, output);
         None
@@ -198,8 +198,8 @@ where
     fn update_view(
         &self,
         widgets: &mut Self::Widgets,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) {
         C::update_view(self, widgets, input, output)
     }

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -28,7 +28,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 /// A future returned by a component's command method.
-pub type CommandFuture<T> = Pin<Box<dyn Future<Output = Option<T>> + Send>>;
+pub type CommandFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 
 /// Contains the initial model and widgets being docked into a component.
 #[derive(Debug)]

--- a/src/component/state_watcher.rs
+++ b/src/component/state_watcher.rs
@@ -1,7 +1,5 @@
 use super::ComponentParts;
 use std::cell::{Ref, RefCell, RefMut};
-use std::rc::Rc;
-use tokio::sync::Notify;
 
 /// Keeps track of a components model and view.
 ///
@@ -10,7 +8,7 @@ use tokio::sync::Notify;
 pub struct StateWatcher<Component, Widgets> {
     /// The models and widgets maintained by the component.
     pub(super) state: RefCell<ComponentParts<Component, Widgets>>,
-    pub(super) notifier: Rc<Notify>,
+    pub(super) notifier: flume::Sender<()>,
 }
 
 impl<Component, Widgets> StateWatcher<Component, Widgets> {
@@ -21,7 +19,7 @@ impl<Component, Widgets> StateWatcher<Component, Widgets> {
 
     /// Borrows the model and view of a component, and notifies the component to check for updates.
     pub fn get_mut(&self) -> RefMut<'_, ComponentParts<Component, Widgets>> {
-        self.notifier.notify_one();
+        let _ = self.notifier.send(());
         self.state.borrow_mut()
     }
 }

--- a/src/component/stateful.rs
+++ b/src/component/stateful.rs
@@ -86,8 +86,9 @@ pub trait StatefulComponent: Sized + 'static {
     fn command(
         message: Self::Command,
         shutdown: ShutdownReceiver,
-    ) -> CommandFuture<Self::CommandOutput> {
-        Box::pin(async move { None })
+        out: Sender<Self::CommandOutput>,
+    ) -> CommandFuture {
+        Box::pin(async {})
     }
 
     /// Last method called before a component is shut down.

--- a/src/component/stateful.rs
+++ b/src/component/stateful.rs
@@ -86,4 +86,8 @@ pub trait StatefulComponent: Sized + 'static {
     fn command(message: Self::Command) -> CommandFuture<Self::CommandOutput> {
         Box::pin(async move { None })
     }
+
+    /// Last method called before a component is shut down.
+    #[allow(unused)]
+    fn shutdown(&mut self, widgets: &mut Self::Widgets, output: Sender<Self::Output>) {}
 }

--- a/src/component/stateful.rs
+++ b/src/component/stateful.rs
@@ -44,8 +44,8 @@ pub trait StatefulComponent: Sized + 'static {
     fn init_parts(
         params: Self::InitParams,
         root: &Self::Root,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) -> ComponentParts<Self, Self::Widgets>;
 
     /// Processes inputs received by the component.
@@ -54,8 +54,8 @@ pub trait StatefulComponent: Sized + 'static {
         &mut self,
         widgets: &mut Self::Widgets,
         message: Self::Input,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) -> Option<Self::Command> {
         None
     }
@@ -66,8 +66,8 @@ pub trait StatefulComponent: Sized + 'static {
         &mut self,
         widgets: &mut Self::Widgets,
         message: Self::CommandOutput,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) {
     }
 
@@ -76,8 +76,8 @@ pub trait StatefulComponent: Sized + 'static {
     fn update_notify(
         &mut self,
         widgets: &mut Self::Widgets,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
+        input: &Sender<Self::Input>,
+        output: &Sender<Self::Output>,
     ) {
     }
 

--- a/src/component/stateful.rs
+++ b/src/component/stateful.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 
 use super::*;
-use crate::{Sender, ShutdownReceiver};
+use crate::{shutdown::ShutdownReceiver, Sender};
 use std::marker::PhantomData;
 
 /// Component with view updates happening at the same time as model updates.

--- a/src/component/stateful.rs
+++ b/src/component/stateful.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 
 use super::*;
-use crate::Sender;
+use crate::{Sender, ShutdownReceiver};
 use std::marker::PhantomData;
 
 /// Component with view updates happening at the same time as model updates.
@@ -83,7 +83,10 @@ pub trait StatefulComponent: Sized + 'static {
 
     /// A command to perform in a background thread.
     #[allow(unused)]
-    fn command(message: Self::Command) -> CommandFuture<Self::CommandOutput> {
+    fn command(
+        message: Self::Command,
+        shutdown: ShutdownReceiver,
+    ) -> CommandFuture<Self::CommandOutput> {
         Box::pin(async move { None })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ mod worker;
 
 pub use self::component::*;
 pub use self::extensions::*;
+pub use self::shutdown::ShutdownReceiver;
 pub use self::worker::*;
 pub use app::RelmApp;
 pub use tokio::task::JoinHandle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,23 +61,6 @@ pub use relm4_macros::*;
 /// Re-export of libadwaita
 pub use adw;
 
-/// Forwards an event from one channel to another.
-pub async fn forward<Transformer, Input, Output>(
-    mut receiver: Receiver<Input>,
-    sender: Sender<Output>,
-    transformer: Transformer,
-) where
-    Transformer: (Fn(Input) -> Output) + 'static,
-    Input: 'static,
-    Output: 'static,
-{
-    while let Some(event) = receiver.recv().await {
-        if sender.0.send(transformer(event)).is_err() {
-            break;
-        }
-    }
-}
-
 /// Sets a custom global stylesheet.
 ///
 /// # Panics

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod actions;
 mod app;
+mod channel;
 mod component;
 pub mod drawing;
 mod extensions;
@@ -26,6 +27,7 @@ pub mod shutdown;
 pub mod util;
 mod worker;
 
+pub use self::channel::*;
 pub use self::component::*;
 pub use self::extensions::*;
 pub use self::shutdown::ShutdownReceiver;
@@ -37,13 +39,6 @@ pub use util::widget_plus::WidgetPlus;
 use once_cell::sync::OnceCell;
 use std::future::Future;
 use tokio::runtime::Runtime;
-use tokio::sync::mpsc;
-
-/// Re-export of `tokio::sync::mpsc::UnboundedSender`.
-pub type Sender<T> = mpsc::UnboundedSender<T>;
-
-/// Re-export of `tokio::sync::mpsc::UnboundedReceiver`.
-pub type Receiver<T> = mpsc::UnboundedReceiver<T>;
 
 /// Defines how many threads that Relm should use for background tasks.
 ///
@@ -77,7 +72,7 @@ pub async fn forward<Transformer, Input, Output>(
     Output: 'static,
 {
     while let Some(event) = receiver.recv().await {
-        if sender.send(transformer(event)).is_err() {
+        if sender.0.send(transformer(event)).is_err() {
             break;
         }
     }
@@ -161,6 +156,6 @@ where
 #[macro_export]
 macro_rules! send {
     ($sender:expr, $msg:expr) => {
-        $sender.send($msg).expect("Receiver was dropped!")
+        $sender.send($msg)
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,13 +32,16 @@ pub use util::widget_plus::WidgetPlus;
 use once_cell::sync::OnceCell;
 use std::future::Future;
 use tokio::runtime::Runtime;
-use tokio::sync::mpsc;
+use tokio::sync::{broadcast, mpsc};
 
 /// Re-export of `tokio::sync::mpsc::UnboundedSender`.
 pub type Sender<T> = mpsc::UnboundedSender<T>;
 
 /// Re-export of `tokio::sync::mpsc::UnboundedReceiver`.
 pub type Receiver<T> = mpsc::UnboundedReceiver<T>;
+
+/// A broadcast receiver which receives a message when a component is deceased.
+pub type ShutdownReceiver = broadcast::Receiver<()>;
 
 /// Defines how many threads that Relm should use for background tasks.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,10 @@ mod component;
 pub mod drawing;
 mod extensions;
 pub mod factory;
+
+/// Cancellation mechanism used by Relm
+pub mod shutdown;
+
 pub mod util;
 mod worker;
 
@@ -32,16 +36,13 @@ pub use util::widget_plus::WidgetPlus;
 use once_cell::sync::OnceCell;
 use std::future::Future;
 use tokio::runtime::Runtime;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::mpsc;
 
 /// Re-export of `tokio::sync::mpsc::UnboundedSender`.
 pub type Sender<T> = mpsc::UnboundedSender<T>;
 
 /// Re-export of `tokio::sync::mpsc::UnboundedReceiver`.
 pub type Receiver<T> = mpsc::UnboundedReceiver<T>;
-
-/// A broadcast receiver which receives a message when a component is deceased.
-pub type ShutdownReceiver = broadcast::Receiver<()>;
 
 /// Defines how many threads that Relm should use for background tasks.
 ///

--- a/src/shutdown/attached.rs
+++ b/src/shutdown/attached.rs
@@ -1,0 +1,43 @@
+use super::ShutdownReceiver;
+use futures::future::Either;
+use std::future::Future;
+
+/// A future attached to a shutdown receiver.
+#[derive(Debug)]
+pub struct AttachedShutdown<F> {
+    pub(super) receiver: ShutdownReceiver,
+    pub(super) future: F,
+}
+
+impl<F, Out> AttachedShutdown<F>
+where
+    F: Future<Output = Out>,
+{
+    /// Creates a future which will resolve to this on shutdown.
+    pub async fn on_shutdown<S>(self, shutdown: S) -> Out
+    where
+        S: Future<Output = Out>,
+    {
+        match self.wait().await {
+            Either::Left(_) => shutdown.await,
+            Either::Right(out) => out,
+        }
+    }
+
+    /// Waits until a shutdown signal is received.
+    ///
+    /// - `Either::Left(())` on cancelation.
+    /// - `Either::Right(Out)` on registered future completion.
+    pub async fn wait(self) -> Either<(), Out> {
+        let Self { receiver, future } = self;
+
+        let cancel = receiver.wait();
+        futures::pin_mut!(cancel);
+        futures::pin_mut!(future);
+
+        match futures::future::select(cancel, future).await {
+            Either::Left(_) => Either::Left(()),
+            Either::Right((out, _)) => Either::Right(out),
+        }
+    }
+}

--- a/src/shutdown/attached.rs
+++ b/src/shutdown/attached.rs
@@ -43,4 +43,11 @@ where
             Either::Right((out, _)) => Either::Right(out),
         }
     }
+
+    /// Waits until a shutdown signal is received.
+    ///
+    /// Ignores any output when we don't care about it.
+    pub async fn wait_then_drop(self) {
+        let _ = self.wait().await;
+    }
 }

--- a/src/shutdown/attached.rs
+++ b/src/shutdown/attached.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 System76 <info@system76.com>
+// SPDX-License-Identifier: MIT or Apache-2.0
+
 use super::ShutdownReceiver;
 use futures::future::Either;
 use std::future::Future;

--- a/src/shutdown/attached.rs
+++ b/src/shutdown/attached.rs
@@ -47,7 +47,7 @@ where
     /// Waits until a shutdown signal is received.
     ///
     /// Ignores any output when we don't care about it.
-    pub async fn wait_then_drop(self) {
+    pub async fn drop_on_shutdown(self) {
         let _ = self.wait().await;
     }
 }

--- a/src/shutdown/mod.rs
+++ b/src/shutdown/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 System76 <info@system76.com>
+// SPDX-License-Identifier: MIT or Apache-2.0
+
 mod attached;
 mod receiver;
 mod sender;

--- a/src/shutdown/mod.rs
+++ b/src/shutdown/mod.rs
@@ -9,6 +9,9 @@ pub use self::attached::AttachedShutdown;
 pub use self::receiver::ShutdownReceiver;
 pub use self::sender::ShutdownSender;
 
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
 use tokio::sync::broadcast;
 
 /// Creates a broadcasting shutdown channel.
@@ -16,11 +19,17 @@ use tokio::sync::broadcast;
 /// The sending side is responsible for initiating a shutdown.
 /// The receiving side is responsible for responding to shutdowns.
 pub fn channel() -> (ShutdownSender, ShutdownReceiver) {
+    let alive = Arc::new(AtomicBool::new(true));
     let (sender, receiver) = broadcast::channel(1);
     (
         ShutdownSender {
+            alive: alive.clone(),
             sender: sender.clone(),
         },
-        ShutdownReceiver { sender, receiver },
+        ShutdownReceiver {
+            alive,
+            sender,
+            receiver,
+        },
     )
 }

--- a/src/shutdown/mod.rs
+++ b/src/shutdown/mod.rs
@@ -12,24 +12,18 @@ pub use self::sender::ShutdownSender;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use tokio::sync::broadcast;
-
 /// Creates a broadcasting shutdown channel.
 ///
 /// The sending side is responsible for initiating a shutdown.
 /// The receiving side is responsible for responding to shutdowns.
 pub fn channel() -> (ShutdownSender, ShutdownReceiver) {
     let alive = Arc::new(AtomicBool::new(true));
-    let (sender, receiver) = broadcast::channel(1);
+    let (sender, receiver) = async_broadcast::broadcast(1);
     (
         ShutdownSender {
             alive: alive.clone(),
-            sender: sender.clone(),
+            sender: sender,
         },
-        ShutdownReceiver {
-            alive,
-            sender,
-            receiver,
-        },
+        ShutdownReceiver { alive, receiver },
     )
 }

--- a/src/shutdown/mod.rs
+++ b/src/shutdown/mod.rs
@@ -1,0 +1,23 @@
+mod attached;
+mod receiver;
+mod sender;
+
+pub use self::attached::AttachedShutdown;
+pub use self::receiver::ShutdownReceiver;
+pub use self::sender::ShutdownSender;
+
+use tokio::sync::broadcast;
+
+/// Creates a broadcasting shutdown channel.
+///
+/// The sending side is responsible for initiating a shutdown.
+/// The receiving side is responsible for responding to shutdowns.
+pub fn channel() -> (ShutdownSender, ShutdownReceiver) {
+    let (sender, receiver) = broadcast::channel(1);
+    (
+        ShutdownSender {
+            sender: sender.clone(),
+        },
+        ShutdownReceiver { sender, receiver },
+    )
+}

--- a/src/shutdown/receiver.rs
+++ b/src/shutdown/receiver.rs
@@ -7,13 +7,12 @@ use std::sync::{
 };
 
 use super::AttachedShutdown;
-use tokio::sync::broadcast::{Receiver, Sender};
+use async_broadcast::Receiver;
 
 /// Listens to shutdown signals and constructs shutdown futures.
 #[derive(Debug)]
 pub struct ShutdownReceiver {
     pub(super) alive: Arc<AtomicBool>,
-    pub(super) sender: Sender<()>,
     pub(super) receiver: Receiver<()>,
 }
 
@@ -38,8 +37,7 @@ impl Clone for ShutdownReceiver {
     fn clone(&self) -> Self {
         Self {
             alive: self.alive.clone(),
-            sender: self.sender.clone(),
-            receiver: self.sender.subscribe(),
+            receiver: self.receiver.clone(),
         }
     }
 }

--- a/src/shutdown/receiver.rs
+++ b/src/shutdown/receiver.rs
@@ -1,0 +1,33 @@
+use super::AttachedShutdown;
+use tokio::sync::broadcast::{Receiver, Sender};
+
+/// Listens to shutdown signals and constructs shutdown futures.
+#[derive(Debug)]
+pub struct ShutdownReceiver {
+    pub(super) sender: Sender<()>,
+    pub(super) receiver: Receiver<()>,
+}
+
+impl ShutdownReceiver {
+    /// Create a future which will be cancelled on shutdown.
+    pub fn register<F>(self, future: F) -> AttachedShutdown<F> {
+        AttachedShutdown {
+            receiver: self,
+            future,
+        }
+    }
+
+    /// Waits until a shutdown signal is received.
+    pub async fn wait(mut self) {
+        let _ = self.receiver.recv().await;
+    }
+}
+
+impl Clone for ShutdownReceiver {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+            receiver: self.sender.subscribe(),
+        }
+    }
+}

--- a/src/shutdown/receiver.rs
+++ b/src/shutdown/receiver.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 System76 <info@system76.com>
+// SPDX-License-Identifier: MIT or Apache-2.0
+
 use super::AttachedShutdown;
 use tokio::sync::broadcast::{Receiver, Sender};
 

--- a/src/shutdown/sender.rs
+++ b/src/shutdown/sender.rs
@@ -1,0 +1,22 @@
+use tokio::sync::broadcast::Sender;
+
+/// Sends shutdown signals to receivers.
+#[derive(Debug)]
+pub struct ShutdownSender {
+    pub(super) sender: Sender<()>,
+}
+
+impl ShutdownSender {
+    /// Broadcasts a shutdown signal to listening receivers.
+    pub fn shutdown(&self) {
+        let _ = self.sender.send(());
+    }
+}
+
+impl Clone for ShutdownSender {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+        }
+    }
+}

--- a/src/shutdown/sender.rs
+++ b/src/shutdown/sender.rs
@@ -1,9 +1,9 @@
 // Copyright 2022 System76 <info@system76.com>
 // SPDX-License-Identifier: MIT or Apache-2.0
 
+use async_broadcast::Sender;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tokio::sync::broadcast::Sender;
 
 /// Sends shutdown signals to receivers.
 #[derive(Debug)]
@@ -15,7 +15,7 @@ pub struct ShutdownSender {
 impl ShutdownSender {
     /// Broadcasts a shutdown signal to listening receivers.
     pub fn shutdown(&self) {
-        let _ = self.sender.send(());
+        let _ = self.sender.broadcast(());
     }
 }
 

--- a/src/shutdown/sender.rs
+++ b/src/shutdown/sender.rs
@@ -1,3 +1,6 @@
+// Copyright 2022 System76 <info@system76.com>
+// SPDX-License-Identifier: MIT or Apache-2.0
+
 use tokio::sync::broadcast::Sender;
 
 /// Sends shutdown signals to receivers.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -5,7 +5,6 @@
 use crate::{Receiver, Sender};
 use std::future::Future;
 use std::pin::Pin;
-use tokio::sync::mpsc;
 
 /// A future returned by a component's command method.
 pub type WorkerFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
@@ -28,8 +27,8 @@ pub trait Worker: Sized + Send {
 
     /// Spawns the worker task in the background.
     fn init(params: Self::InputParams) -> WorkerHandle<Self::Input, Self::Output> {
-        let (input_tx, mut input_rx) = mpsc::unbounded_channel::<Self::Input>();
-        let (mut output_tx, output_rx) = mpsc::unbounded_channel::<Self::Output>();
+        let (input_tx, mut input_rx) = crate::channel::<Self::Input>();
+        let (mut output_tx, output_rx) = crate::channel::<Self::Output>();
 
         let worker = {
             let mut input_tx = input_tx.clone();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -112,7 +112,7 @@ impl<Input: 'static, Output: 'static> WorkerHandle<Input, Output> {
             worker,
         } = self;
 
-        crate::spawn_local(crate::forward(receiver, sender_, transform));
+        crate::spawn_local(receiver.forward(sender_, transform));
         WorkerController { sender, worker }
     }
 }


### PR DESCRIPTION
The current component traits have a big problem with handling graceful shutdowns. This change adds a new method to the component traits — `shutdown()` — which allows a component to get one last chance to perform a cleanup routine before its terminated. It also hands a broadcast receiver to each spawned command so that they can be notified of a component shutdown.