### PR TITLE
Add a few improvements to reduce the amount of clone in user code

### DIFF
--- a/src/component/builder/mod.rs
+++ b/src/component/builder/mod.rs
@@ -37,7 +37,7 @@ impl<Component, Root: AsRef<gtk::Widget>> ComponentBuilder<Component, Root> {
 
 impl<Component, Root: AsRef<gtk::Window>> ComponentBuilder<Component, Root> {
     /// Set the component's root widget transient for a given window.
-    pub fn transient_to(self, window: impl AsRef<gtk::Window>) -> Self {
+    pub fn transient_for(self, window: impl AsRef<gtk::Window>) -> Self {
         self.root.as_ref().set_transient_for(Some(window.as_ref()));
 
         self

--- a/src/component/builder/mod.rs
+++ b/src/component/builder/mod.rs
@@ -6,6 +6,7 @@ mod elm_like;
 mod stateful;
 
 use crate::RelmContainerExt;
+use gtk::prelude::GtkWindowExt;
 use std::marker::PhantomData;
 
 /// A component that is ready for docking and launch.
@@ -29,6 +30,15 @@ impl<Component, Root: AsRef<gtk::Widget>> ComponentBuilder<Component, Root> {
     /// Attach the component's root widget to a given container.
     pub fn attach_to(self, container: &impl RelmContainerExt) -> Self {
         container.container_add(self.root.as_ref());
+
+        self
+    }
+}
+
+impl<Component, Root: AsRef<gtk::Window>> ComponentBuilder<Component, Root> {
+    /// Set the component's root widget transient for a given window.
+    pub fn transient_to(self, window: impl AsRef<gtk::Window>) -> Self {
+        self.root.as_ref().set_transient_for(Some(window.as_ref()));
 
         self
     }

--- a/src/component/connector.rs
+++ b/src/component/connector.rs
@@ -30,7 +30,7 @@ impl<Component, Root, Widgets, Input: 'static, Output: 'static>
     /// Forwards output events to the designated sender.
     pub fn forward<X: 'static, F: (Fn(Output) -> X) + 'static>(
         self,
-        sender_: Sender<X>,
+        sender_: &Sender<X>,
         transform: F,
     ) -> Controller<Component, Root, Widgets, Input> {
         let Connector {
@@ -40,7 +40,7 @@ impl<Component, Root, Widgets, Input: 'static, Output: 'static>
             receiver,
         } = self;
 
-        crate::spawn_local(receiver.forward(sender_, transform));
+        crate::spawn_local(receiver.forward(sender_.clone(), transform));
 
         Controller {
             state,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -103,7 +103,7 @@ impl<Input: 'static, Output: 'static> WorkerHandle<Input, Output> {
     /// Forwards output events to the designated sender.
     pub fn forward<X: 'static, F: (Fn(Output) -> X) + 'static>(
         self,
-        sender_: Sender<X>,
+        sender_: &Sender<X>,
         transform: F,
     ) -> WorkerController<Input> {
         let WorkerHandle {
@@ -112,7 +112,7 @@ impl<Input: 'static, Output: 'static> WorkerHandle<Input, Output> {
             worker,
         } = self;
 
-        crate::spawn_local(receiver.forward(sender_, transform));
+        crate::spawn_local(receiver.forward(sender_.clone(), transform));
         WorkerController { sender, worker }
     }
 }


### PR DESCRIPTION
I'm experimenting with the new components in my project. I often find myself cloning stuff, in two situations: 

### 1) I'd like to attach a window or a dialog to a window (here's an example from my code):

```rust
// ... we have a 'window' variable defined somewhere before
let properties = {
            let window = window.clone();
            PropertyWindow::init()
                .update_root(move |w| w.set_transient_for(Some(&window)))
                .launch(())
                .detach()
            };
```

I have to clone the `window` here, as the closure takes ownership of it's arguments.

The new method `transient_to` can help remove this clone. I use 'to' here for the analogy to an existing method, `attach_to`.

```rust
let properties = PropertyWindow::init()
            .transient_to(&window)
            .launch(())
            .detach();
```

### 2) I'd like to forward a message:

```rust
let rules = {
            let sender = sender.clone();
            RuleViewModel::init()
                .launch(data.current_dir_rules())
                .forward(sender, move |msg| {
                    // .. forward stuff here
                });
        };
```

Forward requires ownership of `sender`, so we have to copy it. I changed it now to use a reference:

```rust
let rules = RuleViewModel::init()
            .launch(data.current_dir_rules())
            .forward(&sender, move |msg| {
                // .. forward stuff here
            });
```

P.S. This is my first ever pull request - hope I did it correctly =)