### PR TITLE
Add `RelmRemovableExt::remove_all` and `RelmWidgetExt::iter_children_reverse`

### DIFF
--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -40,8 +40,11 @@ impl ApplicationBuilderExt for gtk::builders::ApplicationBuilder {
 
 /// Additional methods for `gtk::Widget`
 pub trait RelmWidgetExt {
-    /// Iterates across the child widgets of a widget
+    /// Iterates across the child widgets of a widget.
     fn iter_children(&self) -> Box<dyn Iterator<Item = gtk::Widget>>;
+
+    /// Iterates across the child widgets of a widget, in reverse order.
+    fn iter_children_reverse(&self) -> Box<dyn Iterator<Item = gtk::Widget>>;
 
     /// Iterates children of a widget with a closure.
     fn for_each_child<F: FnMut(gtk::Widget) + 'static>(&self, func: F);
@@ -67,6 +70,10 @@ impl<T: gtk::glib::IsA<gtk::Widget>> RelmWidgetExt for T {
 
     fn iter_children(&self) -> Box<dyn Iterator<Item = gtk::Widget>> {
         Box::new(iter_children(self.as_ref()))
+    }
+
+    fn iter_children_reverse(&self) -> Box<dyn Iterator<Item = gtk::Widget>> {
+        Box::new(iter_children_reverse(self.as_ref()))
     }
 
     fn set_size_group(&self, size_group: &gtk::SizeGroup) {
@@ -129,6 +136,19 @@ fn iter_children(widget: &gtk::Widget) -> impl Iterator<Item = gtk::Widget> {
     std::iter::from_fn(move || {
         if let Some(child) = widget.take() {
             widget = child.next_sibling();
+            return Some(child);
+        }
+
+        None
+    })
+}
+
+fn iter_children_reverse(widget: &gtk::Widget) -> impl Iterator<Item = gtk::Widget> {
+    let mut widget = widget.last_child();
+
+    std::iter::from_fn(move || {
+        if let Some(child) = widget.take() {
+            widget = child.prev_sibling();
             return Some(child);
         }
 

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -84,9 +84,6 @@ pub trait RelmListBoxExt {
     /// Get the index of a widget attached to a listbox.
     fn index_of_child(&self, widget: &impl AsRef<gtk::Widget>) -> Option<i32>;
 
-    /// Remove all children from listbox.
-    fn remove_all(&self);
-
     /// Remove the row of a child attached a listbox.
     fn remove_row_of_child(&self, widget: &impl AsRef<gtk::Widget>);
 
@@ -101,12 +98,6 @@ impl RelmListBoxExt for gtk::ListBox {
         }
 
         None
-    }
-
-    fn remove_all(&self) {
-        while let Some(child) = self.last_child() {
-            self.remove(&child);
-        }
     }
 
     fn remove_row_of_child(&self, widget: &impl AsRef<gtk::Widget>) {

--- a/src/extensions/removable.rs
+++ b/src/extensions/removable.rs
@@ -1,20 +1,20 @@
-use crate::RelmSetChildExt;
+use crate::{RelmSetChildExt, RelmWidgetExt};
 use gtk::prelude::*;
 
 /// Widget types which can have widgets removed from them.
-pub trait RelmRemovableExt<'a> {
+pub trait RelmRemovableExt {
     /// Type of children of the container.
-    type Child: 'a;
+    type Child;
     /// Removes the widget from the container
     /// if it is a child of the container.
-    fn container_remove(&self, widget: Self::Child);
+    fn container_remove(&self, widget: &impl AsRef<Self::Child>);
     /// Remove all children from the container.
     fn remove_all(&self);
 }
 
-impl<'a, T: RelmSetChildExt> RelmRemovableExt<'a> for T {
-    type Child = &'a dyn AsRef<gtk::Widget>;
-    fn container_remove(&self, _widget: Self::Child) {
+impl<'a, T: RelmSetChildExt> RelmRemovableExt for T {
+    type Child = gtk::Widget;
+    fn container_remove(&self, _widget: &impl AsRef<Self::Child>) {
         self.container_set_child(None::<&gtk::Widget>);
     }
     fn remove_all(&self) {
@@ -22,10 +22,10 @@ impl<'a, T: RelmSetChildExt> RelmRemovableExt<'a> for T {
     }
 }
 
-impl<'a> RelmRemovableExt<'a> for gtk::ListBox {
-    type Child = &'a gtk::ListBoxRow;
-    fn container_remove(&self, widget: Self::Child) {
-        self.remove(widget);
+impl RelmRemovableExt for gtk::ListBox {
+    type Child = gtk::ListBoxRow;
+    fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
+        self.remove(widget.as_ref());
     }
     fn remove_all(&self) {
         while let Some(child) = self.last_child() {
@@ -34,12 +34,153 @@ impl<'a> RelmRemovableExt<'a> for gtk::ListBox {
     }
 }
 
+impl RelmRemovableExt for gtk::HeaderBar {
+    type Child = gtk::Widget;
+    fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
+        self.remove(widget.as_ref());
+    }
+    /*
+    To remove all children, assume the following widget structure:
+
+    HeaderBar
+    ╰── WindowHandle
+        ╰── CenterBox
+            ├── Box
+            │   ├── WindowControls
+            │   ╰── [other children] <- to remove
+            |
+            ├── [Title Widget]
+            ╰── Box
+                ├── [other children] <- to remove
+                ╰── WindowControls
+    */
+    fn remove_all(&self) {
+        let handle = self
+            .first_child()
+            .expect("The `HeaderBar` has no children.")
+            .downcast::<gtk::WindowHandle>()
+            .expect("The child of `HeaderBar` is not a `WindowHandle`.");
+
+        let center_box = handle
+            .first_child()
+            .expect("The `WindowHandle` has no children.")
+            .downcast::<gtk::CenterBox>()
+            .expect("The child of `WindowHandle` is not a `CenterBox`.");
+
+        let start_box = center_box
+            .first_child()
+            .expect("The `CenterBox` has no children.")
+            .downcast::<gtk::Box>()
+            .expect("The first child of `CenterBox` is not a `Box`.");
+
+        let title_widget = start_box
+            .next_sibling()
+            .expect("The `CenterBox` has only one child.");
+
+        let end_box = title_widget
+            .next_sibling()
+            .expect("The `CenterBox` has only two children.")
+            .downcast::<gtk::Box>()
+            .expect("The third child of `CenterBox` is not a `Box`.");
+
+        let mut start_children = start_box.iter_children();
+        let mut end_children = end_box.iter_children_reverse();
+
+        let _start_controls = start_children
+            .next()
+            .expect("The start `Box` has no children.")
+            .downcast::<gtk::WindowControls>()
+            .expect("The first child of the start `Box` is not `WindowControls`.");
+
+        let _end_controls = end_children
+            .next()
+            .expect("The end `Box` has no children.")
+            .downcast::<gtk::WindowControls>()
+            .expect("The last child of the end `Box` is not `WindowControls`.");
+
+        for child in start_children {
+            start_box.remove(&child);
+        }
+
+        for child in end_children {
+            end_box.remove(&child);
+        }
+    }
+}
+
+impl RelmRemovableExt for gtk::ActionBar {
+    type Child = gtk::Widget;
+    fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
+        self.remove(widget.as_ref());
+    }
+    /*
+    To remove all children, assume the following widget structure:
+
+    ActionBar
+    ╰── Revealer
+        ╰── CenterBox
+            ├── Box
+            │   ╰── [start children] <- to remove
+            ├── (Optional) [center widget]
+            ╰── Box
+                ╰── [end children] <- to remove
+    */
+    fn remove_all(&self) {
+        let revealer = self
+            .first_child()
+            .expect("The `ActionBar` has no children.")
+            .downcast::<gtk::Revealer>()
+            .expect("The child of `ActionBar` is not a `Revealer`.");
+
+        let center_box = revealer
+            .first_child()
+            .expect("The `Revealer` has no children.")
+            .downcast::<gtk::CenterBox>()
+            .expect("The child of `Revealer` is not a `CenterBox`.");
+
+        let start_box = center_box
+            .first_child()
+            .expect("The `CenterBox` has no children.")
+            .downcast::<gtk::Box>()
+            .expect("The first child of `CenterBox` is not a `Box`.");
+
+        let second_widget = start_box
+            .next_sibling()
+            .expect("The `CenterBox` has only one child.");
+
+        let third_widget = second_widget.next_sibling();
+
+        // Third widget exists: therefore, the `second_widget` is the center widget,
+        // and the `third_widget` is the end box.
+        let end_box = if let Some(widget) = third_widget {
+            widget
+                .downcast::<gtk::Box>()
+                .expect("The third child of `CenterBox` is not a `Box`.")
+        }
+        // Third widget does not exist: therefore, the center widget is not setup,
+        // and the `second_widget` is the end box.
+        else {
+            second_widget
+                .downcast::<gtk::Box>()
+                .expect("The second child of `CenterBox` is not a `Box`.")
+        };
+
+        for child in start_box.iter_children() {
+            start_box.remove(&child);
+        }
+
+        for child in end_box.iter_children_reverse() {
+            end_box.remove(&child);
+        }
+    }
+}
+
 macro_rules! remove_impl {
     ($($type:ty),+) => {
         $(
-            impl<'a> RelmRemovableExt<'a> for $type {
-                type Child = &'a dyn AsRef<gtk::Widget>;
-                fn container_remove(&self, widget: Self::Child) {
+            impl RelmRemovableExt for $type {
+                type Child = gtk::Widget;
+                fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
                     self.remove(widget.as_ref());
                 }
                 fn remove_all(&self) {
@@ -55,9 +196,9 @@ macro_rules! remove_impl {
 macro_rules! remove_child_impl {
     ($($type:ty),+) => {
         $(
-            impl<'a> RelmRemovableExt<'a> for $type {
-                type Child = &'a dyn AsRef<gtk::Widget>;
-                fn container_remove(&self, widget: Self::Child) {
+            impl RelmRemovableExt for $type {
+                type Child = gtk::Widget;
+                fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
                     self.remove_child(widget.as_ref());
                 }
                 fn remove_all(&self) {
@@ -70,13 +211,5 @@ macro_rules! remove_child_impl {
     }
 }
 
-remove_impl!(
-    gtk::Box,
-    gtk::Fixed,
-    gtk::Grid,
-    gtk::ActionBar,
-    gtk::FlowBox,
-    gtk::Stack,
-    gtk::HeaderBar
-);
+remove_impl!(gtk::Box, gtk::Fixed, gtk::Grid, gtk::FlowBox, gtk::Stack);
 remove_child_impl!(gtk::InfoBar);


### PR DESCRIPTION
Introduce `RelmRemovableExt::remove_all` method, which would allow to remove all children from a widget. I think it could be useful.

I've had to change the trait implementation a bit, because otherwise you would have to specify the generic type parameter every time you use this method (like `RelmRemovableExt::<gtk::Widget>::remove_all(&container)`). The static type checking remains though.

If the implementation change is not acceptable for some reason, I can drop it and instead introduce a separate trait for this method.