### PR TITLE
use associated consts for action names

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -17,9 +17,7 @@ macro_rules! new_action_group {
         $vis struct $ty;
 
         impl relm4::actions::ActionGroupName for $ty {
-            fn group_name() -> &'static str {
-                $name
-            }
+            const NAME: &'static str = $name;
         }
     };
 }
@@ -35,9 +33,7 @@ macro_rules! new_stateless_action {
             type Target = ();
             type State = ();
 
-            fn name() -> &'static str {
-                $name
-            }
+            const NAME: &'static str = $name;
         }
     };
 }
@@ -55,9 +51,7 @@ macro_rules! new_stateful_action {
             type Target = $value;
             type State = $state;
 
-            fn name() -> &'static str {
-                $name
-            }
+            const NAME: &'static str = $name;
         }
     };
 }
@@ -84,7 +78,7 @@ where
         let ty = Name::Target::static_variant_type();
 
         let action =
-            gio::SimpleAction::new_stateful(Name::name(), Some(&ty), &start_value.to_variant());
+            gio::SimpleAction::new_stateful(Name::NAME, Some(&ty), &start_value.to_variant());
 
         action.connect_activate(move |action, variant| {
             let value = variant.unwrap().get().unwrap();
@@ -111,7 +105,7 @@ where
         start_value: &Name::State,
         callback: Callback,
     ) -> Self {
-        let action = gio::SimpleAction::new_stateful(Name::name(), None, &start_value.to_variant());
+        let action = gio::SimpleAction::new_stateful(Name::NAME, None, &start_value.to_variant());
 
         action.connect_activate(move |action, _variant| {
             let mut state = action.state().unwrap().get().unwrap();
@@ -137,7 +131,7 @@ where
     ) -> Self {
         let ty = Name::Target::static_variant_type();
 
-        let action = gio::SimpleAction::new(Name::name(), Some(&ty));
+        let action = gio::SimpleAction::new(Name::NAME, Some(&ty));
 
         action.connect_activate(move |action, variant| {
             let value = variant.unwrap().get().unwrap();
@@ -158,7 +152,7 @@ where
 {
     /// Create a new stateless action.
     pub fn new_stateless<Callback: Fn(&gio::SimpleAction) + 'static>(callback: Callback) -> Self {
-        let action = gio::SimpleAction::new(Name::name(), None);
+        let action = gio::SimpleAction::new(Name::NAME, None);
 
         action.connect_activate(move |action, _variant| {
             callback(action);

--- a/src/actions/traits.rs
+++ b/src/actions/traits.rs
@@ -2,8 +2,8 @@ use gtk::prelude::ToVariant;
 
 /// Trait used to specify the group name in [`ActionName`].
 pub trait ActionGroupName {
-    /// Returns the group name.
-    fn group_name() -> &'static str;
+    /// The name of the group.
+    const NAME: &'static str;
 }
 
 /// Trait for marking stateless actions.
@@ -26,12 +26,12 @@ pub trait ActionName {
     /// Use [`()`] for stateless actions.
     type State;
 
-    /// Returns the actions name.
-    fn name() -> &'static str;
+    /// The name of the action.
+    const NAME: &'static str;
 
     /// The full action name (group.action).
     fn action_name() -> String {
-        format!("{}.{}", Self::Group::group_name(), Self::name())
+        format!("{}.{}", Self::Group::NAME, Self::NAME)
     }
 }
 


### PR DESCRIPTION
Minor breaking change to the action traits, but it makes implementing
them manually a bit less verbose. Maybe someday it will let us compute
the full action name at compile-time, too.