### PR TITLE
Drop general extensions in favor of widget-specific extensions

### DIFF
--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -2,6 +2,9 @@ mod container;
 mod removable;
 mod set_child;
 
+#[cfg(test)]
+mod tests;
+
 #[allow(unreachable_pub)]
 pub use self::container::RelmContainerExt;
 #[allow(unreachable_pub)]
@@ -40,15 +43,6 @@ impl ApplicationBuilderExt for gtk::builders::ApplicationBuilder {
 
 /// Additional methods for `gtk::Widget`
 pub trait RelmWidgetExt {
-    /// Iterates across the child widgets of a widget.
-    fn iter_children(&self) -> Box<dyn Iterator<Item = gtk::Widget>>;
-
-    /// Iterates across the child widgets of a widget, in reverse order.
-    fn iter_children_reverse(&self) -> Box<dyn Iterator<Item = gtk::Widget>>;
-
-    /// Iterates children of a widget with a closure.
-    fn for_each_child<F: FnMut(gtk::Widget) + 'static>(&self, func: F);
-
     /// Attach widget to a `gtk::SizeGroup`.
     fn set_size_group(&self, size_group: &gtk::SizeGroup);
 
@@ -59,23 +53,6 @@ pub trait RelmWidgetExt {
 }
 
 impl<T: gtk::glib::IsA<gtk::Widget>> RelmWidgetExt for T {
-    fn for_each_child<F: FnMut(gtk::Widget) + 'static>(&self, mut func: F) {
-        let mut widget = self.first_child();
-
-        while let Some(child) = widget.take() {
-            widget = child.next_sibling();
-            func(child);
-        }
-    }
-
-    fn iter_children(&self) -> Box<dyn Iterator<Item = gtk::Widget>> {
-        Box::new(iter_children(self.as_ref()))
-    }
-
-    fn iter_children_reverse(&self) -> Box<dyn Iterator<Item = gtk::Widget>> {
-        Box::new(iter_children_reverse(self.as_ref()))
-    }
-
     fn set_size_group(&self, size_group: &gtk::SizeGroup) {
         size_group.add_widget(self);
     }
@@ -83,50 +60,6 @@ impl<T: gtk::glib::IsA<gtk::Widget>> RelmWidgetExt for T {
     fn toplevel_window(&self) -> Option<gtk::Window> {
         self.ancestor(gtk::Window::static_type())
             .and_then(|widget| widget.dynamic_cast::<gtk::Window>().ok())
-    }
-}
-
-/// Additional methods for `gtk::ListBox`.
-pub trait RelmListBoxExt {
-    /// Get the index of a widget attached to a listbox.
-    fn index_of_child(&self, widget: &impl AsRef<gtk::Widget>) -> Option<i32>;
-
-    /// Remove the row of a child attached a listbox.
-    fn remove_row_of_child(&self, widget: &impl AsRef<gtk::Widget>);
-
-    /// Get the row of a widget attached to a listbox.
-    fn row_of_child(&self, widget: &impl AsRef<gtk::Widget>) -> Option<gtk::ListBoxRow>;
-}
-
-impl RelmListBoxExt for gtk::ListBox {
-    fn index_of_child(&self, widget: &impl AsRef<gtk::Widget>) -> Option<i32> {
-        if let Some(row) = self.row_of_child(widget) {
-            return Some(row.index());
-        }
-
-        None
-    }
-
-    fn remove_row_of_child(&self, widget: &impl AsRef<gtk::Widget>) {
-        if let Some(row) = self.row_of_child(widget) {
-            self.remove(&row);
-        }
-    }
-
-    fn row_of_child(&self, widget: &impl AsRef<gtk::Widget>) -> Option<gtk::ListBoxRow> {
-        if let Some(row) = widget.as_ref().ancestor(gtk::ListBoxRow::static_type()) {
-            if let Some(row) = row.dynamic_cast_ref::<gtk::ListBoxRow>() {
-                if let Some(parent_widget) = row.parent() {
-                    if let Some(parent_box) = parent_widget.dynamic_cast_ref::<gtk::ListBox>() {
-                        if parent_box == self {
-                            return Some(row.clone());
-                        }
-                    }
-                }
-            }
-        }
-
-        None
     }
 }
 
@@ -143,15 +76,138 @@ fn iter_children(widget: &gtk::Widget) -> impl Iterator<Item = gtk::Widget> {
     })
 }
 
-fn iter_children_reverse(widget: &gtk::Widget) -> impl Iterator<Item = gtk::Widget> {
-    let mut widget = widget.last_child();
+/// Additional methods for `gtk::Box`.
+pub trait RelmBoxExt {
+    /// Returns all children of the box.
+    fn children(&self) -> Vec<gtk::Widget>;
 
-    std::iter::from_fn(move || {
-        if let Some(child) = widget.take() {
-            widget = child.prev_sibling();
-            return Some(child);
+    /// Remove all children from the box.
+    fn remove_all(&self);
+}
+
+impl RelmBoxExt for gtk::Box {
+    fn children(&self) -> Vec<gtk::Widget> {
+        iter_children(self.as_ref()).collect()
+    }
+    fn remove_all(&self) {
+        while let Some(child) = self.last_child() {
+            self.remove(&child);
+        }
+    }
+}
+
+/// Additional methods for `gtk::ListBox`.
+pub trait RelmListBoxExt {
+    /// Returns all rows of the listbox.
+    fn rows(&self) -> Vec<gtk::ListBoxRow>;
+
+    /// Get the index of a widget attached to a listbox.
+    fn index_of_child(&self, widget: &impl AsRef<gtk::Widget>) -> Option<i32>;
+
+    /// Remove all children from listbox.
+    fn remove_all(&self);
+
+    /// Remove the row of a child attached a listbox.
+    fn remove_row_of_child(&self, widget: &impl AsRef<gtk::Widget>);
+
+    /// Get the row of a widget attached to a listbox.
+    fn row_of_child(&self, widget: &impl AsRef<gtk::Widget>) -> Option<gtk::ListBoxRow>;
+}
+
+impl RelmListBoxExt for gtk::ListBox {
+    fn rows(&self) -> Vec<gtk::ListBoxRow> {
+        iter_children(self.as_ref())
+            .map(|widget| {
+                widget
+                    .downcast::<gtk::ListBoxRow>()
+                    .expect("The child of `ListBox` is not a `ListBoxRow`.")
+            })
+            .collect()
+    }
+    fn index_of_child(&self, widget: &impl AsRef<gtk::Widget>) -> Option<i32> {
+        if let Some(row) = self.row_of_child(widget) {
+            return Some(row.index());
         }
 
         None
-    })
+    }
+
+    fn remove_all(&self) {
+        while let Some(child) = self.last_child() {
+            let row = child
+                .downcast::<gtk::ListBoxRow>()
+                .expect("The child of `ListBox` is not a `ListBoxRow`.");
+            row.set_child(None::<&gtk::Widget>);
+            self.remove(&row);
+        }
+    }
+
+    fn remove_row_of_child(&self, widget: &impl AsRef<gtk::Widget>) {
+        if let Some(row) = self.row_of_child(widget) {
+            row.set_child(None::<&gtk::Widget>);
+            self.remove(&row);
+        }
+    }
+
+    fn row_of_child(&self, widget: &impl AsRef<gtk::Widget>) -> Option<gtk::ListBoxRow> {
+        if let Some(row) = widget.as_ref().ancestor(gtk::ListBoxRow::static_type()) {
+            if let Some(row) = row.downcast_ref::<gtk::ListBoxRow>() {
+                if let Some(parent_widget) = row.parent() {
+                    if let Some(parent_box) = parent_widget.downcast_ref::<gtk::ListBox>() {
+                        if parent_box == self {
+                            return Some(row.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        None
+    }
+}
+
+/// Additional methods for `gtk::FlowBox`.
+pub trait RelmFlowBoxExt {
+    /// Returns all children of the flowbox.
+    fn flow_children(&self) -> Vec<gtk::FlowBoxChild>;
+
+    /// Remove all children from the flowbox.
+    fn remove_all(&self);
+}
+
+impl RelmFlowBoxExt for gtk::FlowBox {
+    fn flow_children(&self) -> Vec<gtk::FlowBoxChild> {
+        iter_children(self.as_ref())
+            .map(|widget| {
+                widget
+                    .downcast::<gtk::FlowBoxChild>()
+                    .expect("The child of `FlowBox` is not a `FlowBoxChild`.")
+            })
+            .collect()
+    }
+    fn remove_all(&self) {
+        while let Some(child) = self.last_child() {
+            self.remove(&child);
+        }
+    }
+}
+
+/// Additional methods for `gtk::Grid`.
+pub trait RelmGridExt {
+    /// Returns all children of the grid.
+    fn children(&self) -> Vec<gtk::Widget>;
+
+    /// Remove all children from the grid.
+    fn remove_all(&self);
+}
+
+impl RelmGridExt for gtk::Grid {
+    fn children(&self) -> Vec<gtk::Widget> {
+        iter_children(self.as_ref()).collect()
+    }
+    fn remove_all(&self) {
+        while let Some(child) = self.last_child() {
+            self.remove(&child);
+        }
+    }
 }

--- a/src/extensions/removable.rs
+++ b/src/extensions/removable.rs
@@ -61,3 +61,37 @@ remove_impl!(
     gtk::HeaderBar
 );
 remove_child_impl!(gtk::InfoBar);
+
+/// Widget types that allow removal of all their children.
+pub trait RelmRemoveAllExt {
+    /// Remove all children from the container.
+    fn remove_all(&self);
+}
+
+macro_rules! remove_all_impl {
+    ($($type:ty),+) => {
+        $(
+            impl RelmRemoveAllExt for $type {
+                fn remove_all(&self) {
+                    while let Some(child) = self.last_child() {
+                        self.remove(&child);
+                    }
+                }
+            }
+        )+
+    }
+}
+
+remove_all_impl!(gtk::Box, gtk::FlowBox, gtk::Grid);
+
+impl RelmRemoveAllExt for gtk::ListBox {
+    fn remove_all(&self) {
+        while let Some(child) = self.last_child() {
+            let row = child
+                .downcast::<gtk::ListBoxRow>()
+                .expect("The child of `ListBox` is not a `ListBoxRow`.");
+            row.set_child(None::<&gtk::Widget>);
+            self.remove(&row);
+        }
+    }
+}

--- a/src/extensions/removable.rs
+++ b/src/extensions/removable.rs
@@ -1,192 +1,39 @@
-use crate::{RelmSetChildExt, RelmWidgetExt};
+use crate::RelmSetChildExt;
 use gtk::prelude::*;
 
 /// Widget types which can have widgets removed from them.
-pub trait RelmRemovableExt {
-    /// Type of children of the container.
-    type Child;
+pub trait RelmRemovableExt<W> {
     /// Removes the widget from the container
     /// if it is a child of the container.
-    fn container_remove(&self, widget: &impl AsRef<Self::Child>);
-    /// Remove all children from the container.
-    fn remove_all(&self);
+    fn container_remove(&self, widget: &W);
 }
 
-impl<'a, T: RelmSetChildExt> RelmRemovableExt for T {
-    type Child = gtk::Widget;
-    fn container_remove(&self, _widget: &impl AsRef<Self::Child>) {
-        self.container_set_child(None::<&gtk::Widget>);
-    }
-    fn remove_all(&self) {
+impl<T: RelmSetChildExt, W: AsRef<gtk::Widget>> RelmRemovableExt<W> for T {
+    fn container_remove(&self, _widget: &W) {
         self.container_set_child(None::<&gtk::Widget>);
     }
 }
 
-impl RelmRemovableExt for gtk::ListBox {
-    type Child = gtk::ListBoxRow;
-    fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
-        self.remove(widget.as_ref());
-    }
-    fn remove_all(&self) {
-        while let Some(child) = self.last_child() {
-            self.remove(&child);
-        }
+impl<W: AsRef<gtk::ListBoxRow>> RelmRemovableExt<W> for gtk::ListBox {
+    fn container_remove(&self, widget: &W) {
+        let row = widget.as_ref();
+        row.set_child(None::<&gtk::Widget>);
+        self.remove(row);
     }
 }
 
-impl RelmRemovableExt for gtk::HeaderBar {
-    type Child = gtk::Widget;
-    fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
+impl<W: AsRef<gtk::FlowBoxChild>> RelmRemovableExt<W> for gtk::FlowBox {
+    fn container_remove(&self, widget: &W) {
         self.remove(widget.as_ref());
-    }
-    /*
-    To remove all children, assume the following widget structure:
-
-    HeaderBar
-    ╰── WindowHandle
-        ╰── CenterBox
-            ├── Box
-            │   ├── WindowControls
-            │   ╰── [other children] <- to remove
-            |
-            ├── [Title Widget]
-            ╰── Box
-                ├── [other children] <- to remove
-                ╰── WindowControls
-    */
-    fn remove_all(&self) {
-        let handle = self
-            .first_child()
-            .expect("The `HeaderBar` has no children.")
-            .downcast::<gtk::WindowHandle>()
-            .expect("The child of `HeaderBar` is not a `WindowHandle`.");
-
-        let center_box = handle
-            .first_child()
-            .expect("The `WindowHandle` has no children.")
-            .downcast::<gtk::CenterBox>()
-            .expect("The child of `WindowHandle` is not a `CenterBox`.");
-
-        let start_box = center_box
-            .first_child()
-            .expect("The `CenterBox` has no children.")
-            .downcast::<gtk::Box>()
-            .expect("The first child of `CenterBox` is not a `Box`.");
-
-        let title_widget = start_box
-            .next_sibling()
-            .expect("The `CenterBox` has only one child.");
-
-        let end_box = title_widget
-            .next_sibling()
-            .expect("The `CenterBox` has only two children.")
-            .downcast::<gtk::Box>()
-            .expect("The third child of `CenterBox` is not a `Box`.");
-
-        let mut start_children = start_box.iter_children();
-        let mut end_children = end_box.iter_children_reverse();
-
-        let _start_controls = start_children
-            .next()
-            .expect("The start `Box` has no children.")
-            .downcast::<gtk::WindowControls>()
-            .expect("The first child of the start `Box` is not `WindowControls`.");
-
-        let _end_controls = end_children
-            .next()
-            .expect("The end `Box` has no children.")
-            .downcast::<gtk::WindowControls>()
-            .expect("The last child of the end `Box` is not `WindowControls`.");
-
-        for child in start_children {
-            start_box.remove(&child);
-        }
-
-        for child in end_children {
-            end_box.remove(&child);
-        }
-    }
-}
-
-impl RelmRemovableExt for gtk::ActionBar {
-    type Child = gtk::Widget;
-    fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
-        self.remove(widget.as_ref());
-    }
-    /*
-    To remove all children, assume the following widget structure:
-
-    ActionBar
-    ╰── Revealer
-        ╰── CenterBox
-            ├── Box
-            │   ╰── [start children] <- to remove
-            ├── (Optional) [center widget]
-            ╰── Box
-                ╰── [end children] <- to remove
-    */
-    fn remove_all(&self) {
-        let revealer = self
-            .first_child()
-            .expect("The `ActionBar` has no children.")
-            .downcast::<gtk::Revealer>()
-            .expect("The child of `ActionBar` is not a `Revealer`.");
-
-        let center_box = revealer
-            .first_child()
-            .expect("The `Revealer` has no children.")
-            .downcast::<gtk::CenterBox>()
-            .expect("The child of `Revealer` is not a `CenterBox`.");
-
-        let start_box = center_box
-            .first_child()
-            .expect("The `CenterBox` has no children.")
-            .downcast::<gtk::Box>()
-            .expect("The first child of `CenterBox` is not a `Box`.");
-
-        let second_widget = start_box
-            .next_sibling()
-            .expect("The `CenterBox` has only one child.");
-
-        let third_widget = second_widget.next_sibling();
-
-        // Third widget exists: therefore, the `second_widget` is the center widget,
-        // and the `third_widget` is the end box.
-        let end_box = if let Some(widget) = third_widget {
-            widget
-                .downcast::<gtk::Box>()
-                .expect("The third child of `CenterBox` is not a `Box`.")
-        }
-        // Third widget does not exist: therefore, the center widget is not setup,
-        // and the `second_widget` is the end box.
-        else {
-            second_widget
-                .downcast::<gtk::Box>()
-                .expect("The second child of `CenterBox` is not a `Box`.")
-        };
-
-        for child in start_box.iter_children() {
-            start_box.remove(&child);
-        }
-
-        for child in end_box.iter_children_reverse() {
-            end_box.remove(&child);
-        }
     }
 }
 
 macro_rules! remove_impl {
     ($($type:ty),+) => {
         $(
-            impl RelmRemovableExt for $type {
-                type Child = gtk::Widget;
-                fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
+            impl<W: AsRef<gtk::Widget>> RelmRemovableExt<W> for $type {
+                fn container_remove(&self, widget: &W) {
                     self.remove(widget.as_ref());
-                }
-                fn remove_all(&self) {
-                    while let Some(child) = self.last_child() {
-                        self.remove(&child);
-                    }
                 }
             }
         )+
@@ -196,20 +43,21 @@ macro_rules! remove_impl {
 macro_rules! remove_child_impl {
     ($($type:ty),+) => {
         $(
-            impl RelmRemovableExt for $type {
-                type Child = gtk::Widget;
-                fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
+            impl<W: AsRef<gtk::Widget>> RelmRemovableExt<W> for $type {
+                fn container_remove(&self, widget: &W) {
                     self.remove_child(widget.as_ref());
-                }
-                fn remove_all(&self) {
-                    while let Some(child) = self.last_child() {
-                        self.remove_child(&child);
-                    }
                 }
             }
         )+
     }
 }
 
-remove_impl!(gtk::Box, gtk::Fixed, gtk::Grid, gtk::FlowBox, gtk::Stack);
+remove_impl!(
+    gtk::Box,
+    gtk::Fixed,
+    gtk::Grid,
+    gtk::ActionBar,
+    gtk::Stack,
+    gtk::HeaderBar
+);
 remove_child_impl!(gtk::InfoBar);

--- a/src/extensions/removable.rs
+++ b/src/extensions/removable.rs
@@ -2,28 +2,33 @@ use crate::RelmSetChildExt;
 use gtk::prelude::*;
 
 /// Widget types which can have widgets removed from them.
-pub trait RelmRemovableExt<W> {
+pub trait RelmRemovableExt {
+    /// Type of container children.
+    type Child: IsA<gtk::Widget>;
     /// Removes the widget from the container
     /// if it is a child of the container.
-    fn container_remove(&self, widget: &W);
+    fn container_remove(&self, widget: &impl AsRef<Self::Child>);
 }
 
-impl<T: RelmSetChildExt, W: AsRef<gtk::Widget>> RelmRemovableExt<W> for T {
-    fn container_remove(&self, _widget: &W) {
+impl<T: RelmSetChildExt> RelmRemovableExt for T {
+    type Child = gtk::Widget;
+    fn container_remove(&self, _widget: &impl AsRef<Self::Child>) {
         self.container_set_child(None::<&gtk::Widget>);
     }
 }
 
-impl<W: AsRef<gtk::ListBoxRow>> RelmRemovableExt<W> for gtk::ListBox {
-    fn container_remove(&self, widget: &W) {
+impl RelmRemovableExt for gtk::ListBox {
+    type Child = gtk::ListBoxRow;
+    fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
         let row = widget.as_ref();
         row.set_child(None::<&gtk::Widget>);
         self.remove(row);
     }
 }
 
-impl<W: AsRef<gtk::FlowBoxChild>> RelmRemovableExt<W> for gtk::FlowBox {
-    fn container_remove(&self, widget: &W) {
+impl RelmRemovableExt for gtk::FlowBox {
+    type Child = gtk::FlowBoxChild;
+    fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
         self.remove(widget.as_ref());
     }
 }
@@ -31,8 +36,9 @@ impl<W: AsRef<gtk::FlowBoxChild>> RelmRemovableExt<W> for gtk::FlowBox {
 macro_rules! remove_impl {
     ($($type:ty),+) => {
         $(
-            impl<W: AsRef<gtk::Widget>> RelmRemovableExt<W> for $type {
-                fn container_remove(&self, widget: &W) {
+            impl RelmRemovableExt for $type {
+                type Child = gtk::Widget;
+                fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
                     self.remove(widget.as_ref());
                 }
             }
@@ -43,8 +49,9 @@ macro_rules! remove_impl {
 macro_rules! remove_child_impl {
     ($($type:ty),+) => {
         $(
-            impl<W: AsRef<gtk::Widget>> RelmRemovableExt<W> for $type {
-                fn container_remove(&self, widget: &W) {
+            impl RelmRemovableExt for $type {
+                type Child = gtk::Widget;
+                fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
                     self.remove_child(widget.as_ref());
                 }
             }

--- a/src/extensions/tests.rs
+++ b/src/extensions/tests.rs
@@ -26,7 +26,7 @@ fn same_widgets(
 }
 
 #[gtk::test]
-fn box_ext() {
+fn box_extension_traits() {
     let gtk_box = gtk::Box::default();
     let widgets = TestWidgets::default();
 
@@ -38,9 +38,10 @@ fn box_ext() {
 
     let mut children = gtk_box.iter_children();
     assert!(same_widgets(children.next(), Some(&widgets.0)));
+    assert!(same_widgets(children.next_back(), Some(&widgets.2)));
     assert!(same_widgets(children.next(), Some(&widgets.1)));
-    assert!(same_widgets(children.next(), Some(&widgets.2)));
     assert_eq!(children.next(), None);
+    assert_eq!(children.next_back(), None);
 
     gtk_box.remove_all();
 
@@ -48,7 +49,7 @@ fn box_ext() {
 }
 
 #[gtk::test]
-fn list_box_ext() {
+fn list_box_extension_traits() {
     let list_box = gtk::ListBox::default();
     let widgets = TestWidgets::default();
 
@@ -63,10 +64,11 @@ fn list_box_ext() {
     assert_eq!(list_box.index_of_child(&widgets.2), Some(2));
 
     let mut rows = list_box.iter_children();
+    assert!(same_widgets(rows.next_back(), widgets.2.parent()));
     assert!(same_widgets(rows.next(), widgets.0.parent()));
     assert!(same_widgets(rows.next(), widgets.1.parent()));
-    assert!(same_widgets(rows.next(), widgets.2.parent()));
     assert_eq!(rows.next(), None);
+    assert_eq!(rows.next_back(), None);
 
     list_box.remove_all();
 
@@ -90,7 +92,7 @@ fn list_box_ext() {
 }
 
 #[gtk::test]
-fn flow_box_ext() {
+fn flow_box_extension_traits() {
     let flow_box = gtk::FlowBox::default();
     let widgets = TestWidgets::default();
 
@@ -105,6 +107,7 @@ fn flow_box_ext() {
     assert!(same_widgets(flow_children.next(), widgets.1.parent()));
     assert!(same_widgets(flow_children.next(), widgets.2.parent()));
     assert_eq!(flow_children.next(), None);
+    assert_eq!(flow_children.next_back(), None);
 
     flow_box.remove_all();
 
@@ -112,7 +115,7 @@ fn flow_box_ext() {
 }
 
 #[gtk::test]
-fn grid_ext() {
+fn grid_extension_traits() {
     let grid = gtk::Grid::default();
     let widgets = TestWidgets::default();
 
@@ -127,6 +130,7 @@ fn grid_ext() {
     assert!(same_widgets(children.next(), Some(&widgets.1)));
     assert!(same_widgets(children.next(), Some(&widgets.2)));
     assert_eq!(children.next(), None);
+    assert_eq!(children.next_back(), None);
 
     grid.remove_all();
 

--- a/src/extensions/tests.rs
+++ b/src/extensions/tests.rs
@@ -1,0 +1,138 @@
+use crate::{gtk, RelmBoxExt, RelmFlowBoxExt, RelmGridExt, RelmListBoxExt};
+use gtk::prelude::{BoxExt, GridExt, WidgetExt};
+
+// A set of widgets for testing
+#[derive(Default)]
+struct TestWidgets(gtk::Label, gtk::Switch, gtk::Box);
+
+impl TestWidgets {
+    fn assert_parent(&self) {
+        assert!(self.0.parent().is_some());
+        assert!(self.1.parent().is_some());
+        assert!(self.2.parent().is_some());
+    }
+}
+
+#[gtk::test]
+fn box_ext() {
+    let gtk_box = gtk::Box::default();
+    let widgets = TestWidgets::default();
+
+    gtk_box.append(&widgets.0);
+    gtk_box.append(&widgets.1);
+    gtk_box.append(&widgets.2);
+
+    widgets.assert_parent();
+
+    let children = gtk_box.children();
+    assert_eq!(children.get(0), Some(widgets.0.as_ref()));
+    assert_eq!(children.get(1), Some(widgets.1.as_ref()));
+    assert_eq!(children.get(2), Some(widgets.2.as_ref()));
+
+    gtk_box.remove_all();
+
+    assert_eq!(gtk_box.children().len(), 0);
+}
+
+#[gtk::test]
+fn list_box_ext() {
+    let list_box = gtk::ListBox::default();
+    let widgets = TestWidgets::default();
+
+    list_box.append(&widgets.0);
+    list_box.append(&widgets.1);
+    list_box.append(&widgets.2);
+
+    widgets.assert_parent();
+
+    assert_eq!(list_box.index_of_child(&widgets.0), Some(0));
+    assert_eq!(list_box.index_of_child(&widgets.1), Some(1));
+    assert_eq!(list_box.index_of_child(&widgets.2), Some(2));
+
+    let rows = list_box.rows();
+    assert_eq!(
+        rows.get(0).map(|row| row.as_ref()),
+        widgets.0.parent().as_ref()
+    );
+    assert_eq!(
+        rows.get(1).map(|row| row.as_ref()),
+        widgets.1.parent().as_ref()
+    );
+    assert_eq!(
+        rows.get(2).map(|row| row.as_ref()),
+        widgets.2.parent().as_ref()
+    );
+
+    list_box.remove_all();
+
+    assert_eq!(list_box.rows().len(), 0);
+
+    list_box.append(&widgets.0);
+    list_box.append(&widgets.1);
+    list_box.append(&widgets.2);
+
+    widgets.assert_parent();
+
+    list_box.remove_row_of_child(&widgets.0);
+    list_box.remove_row_of_child(&widgets.1);
+    list_box.remove_row_of_child(&widgets.2);
+
+    assert_eq!(list_box.rows().len(), 0);
+
+    assert_eq!(list_box.index_of_child(&widgets.0), None);
+    assert_eq!(list_box.index_of_child(&widgets.1), None);
+    assert_eq!(list_box.index_of_child(&widgets.2), None);
+}
+
+#[gtk::test]
+fn flow_box_ext() {
+    let flow_box = gtk::FlowBox::default();
+    let widgets = TestWidgets::default();
+
+    flow_box.insert(&widgets.0, -1);
+    flow_box.insert(&widgets.1, -1);
+    flow_box.insert(&widgets.2, -1);
+
+    widgets.assert_parent();
+
+    let flow_children = flow_box.flow_children();
+    assert_eq!(
+        flow_children.get(0).map(|child| child.as_ref()),
+        widgets.0.parent().as_ref()
+    );
+    assert_eq!(
+        flow_children.get(1).map(|child| child.as_ref()),
+        widgets.1.parent().as_ref()
+    );
+    assert_eq!(
+        flow_children.get(2).map(|child| child.as_ref()),
+        widgets.2.parent().as_ref()
+    );
+
+    flow_box.remove_all();
+
+    assert_eq!(flow_box.flow_children().len(), 0);
+}
+
+#[gtk::test]
+fn grid_ext() {
+    let grid = gtk::Grid::default();
+    let widgets = TestWidgets::default();
+
+    grid.attach(&widgets.0, 0, 0, 1, 1);
+    grid.attach(&widgets.1, 1, 0, 1, 1);
+    grid.attach(&widgets.2, 2, 2, 2, 2);
+
+    widgets.assert_parent();
+
+    let children = grid.children();
+    assert_eq!(children.get(0), Some(widgets.0.as_ref()));
+    assert_eq!(children.get(1), Some(widgets.1.as_ref()));
+    assert_eq!(children.get(2), Some(widgets.2.as_ref()));
+
+    grid.remove_all();
+
+    assert!(widgets.0.parent().is_none());
+    assert!(widgets.1.parent().is_none());
+    assert!(widgets.2.parent().is_none());
+}

--- a/src/extensions/tests.rs
+++ b/src/extensions/tests.rs
@@ -1,7 +1,7 @@
-use crate::{gtk, RelmBoxExt, RelmFlowBoxExt, RelmGridExt, RelmListBoxExt};
+use crate::{gtk, RelmIterChildrenExt, RelmListBoxExt, RelmRemoveAllExt};
 use gtk::prelude::{BoxExt, GridExt, WidgetExt};
 
-// A set of widgets for testing
+// A set of widgets for tests
 #[derive(Default)]
 struct TestWidgets(gtk::Label, gtk::Switch, gtk::Box);
 
@@ -10,6 +10,18 @@ impl TestWidgets {
         assert!(self.0.parent().is_some());
         assert!(self.1.parent().is_some());
         assert!(self.2.parent().is_some());
+    }
+}
+
+// Returns whether two optional widgets are the same.
+fn same_widgets(
+    first: Option<impl AsRef<gtk::Widget>>,
+    second: Option<impl AsRef<gtk::Widget>>,
+) -> bool {
+    match (first, second) {
+        (Some(first), Some(second)) => first.as_ref() == second.as_ref(),
+        (None, None) => true,
+        _ => false,
     }
 }
 
@@ -24,14 +36,15 @@ fn box_ext() {
 
     widgets.assert_parent();
 
-    let children = gtk_box.children();
-    assert_eq!(children.get(0), Some(widgets.0.as_ref()));
-    assert_eq!(children.get(1), Some(widgets.1.as_ref()));
-    assert_eq!(children.get(2), Some(widgets.2.as_ref()));
+    let mut children = gtk_box.iter_children();
+    assert!(same_widgets(children.next(), Some(&widgets.0)));
+    assert!(same_widgets(children.next(), Some(&widgets.1)));
+    assert!(same_widgets(children.next(), Some(&widgets.2)));
+    assert_eq!(children.next(), None);
 
     gtk_box.remove_all();
 
-    assert_eq!(gtk_box.children().len(), 0);
+    assert_eq!(gtk_box.iter_children().next(), None);
 }
 
 #[gtk::test]
@@ -49,23 +62,15 @@ fn list_box_ext() {
     assert_eq!(list_box.index_of_child(&widgets.1), Some(1));
     assert_eq!(list_box.index_of_child(&widgets.2), Some(2));
 
-    let rows = list_box.rows();
-    assert_eq!(
-        rows.get(0).map(|row| row.as_ref()),
-        widgets.0.parent().as_ref()
-    );
-    assert_eq!(
-        rows.get(1).map(|row| row.as_ref()),
-        widgets.1.parent().as_ref()
-    );
-    assert_eq!(
-        rows.get(2).map(|row| row.as_ref()),
-        widgets.2.parent().as_ref()
-    );
+    let mut rows = list_box.iter_children();
+    assert!(same_widgets(rows.next(), widgets.0.parent()));
+    assert!(same_widgets(rows.next(), widgets.1.parent()));
+    assert!(same_widgets(rows.next(), widgets.2.parent()));
+    assert_eq!(rows.next(), None);
 
     list_box.remove_all();
 
-    assert_eq!(list_box.rows().len(), 0);
+    assert_eq!(list_box.iter_children().next(), None);
 
     list_box.append(&widgets.0);
     list_box.append(&widgets.1);
@@ -77,7 +82,7 @@ fn list_box_ext() {
     list_box.remove_row_of_child(&widgets.1);
     list_box.remove_row_of_child(&widgets.2);
 
-    assert_eq!(list_box.rows().len(), 0);
+    assert_eq!(list_box.iter_children().next(), None);
 
     assert_eq!(list_box.index_of_child(&widgets.0), None);
     assert_eq!(list_box.index_of_child(&widgets.1), None);
@@ -95,23 +100,15 @@ fn flow_box_ext() {
 
     widgets.assert_parent();
 
-    let flow_children = flow_box.flow_children();
-    assert_eq!(
-        flow_children.get(0).map(|child| child.as_ref()),
-        widgets.0.parent().as_ref()
-    );
-    assert_eq!(
-        flow_children.get(1).map(|child| child.as_ref()),
-        widgets.1.parent().as_ref()
-    );
-    assert_eq!(
-        flow_children.get(2).map(|child| child.as_ref()),
-        widgets.2.parent().as_ref()
-    );
+    let mut flow_children = flow_box.iter_children();
+    assert!(same_widgets(flow_children.next(), widgets.0.parent()));
+    assert!(same_widgets(flow_children.next(), widgets.1.parent()));
+    assert!(same_widgets(flow_children.next(), widgets.2.parent()));
+    assert_eq!(flow_children.next(), None);
 
     flow_box.remove_all();
 
-    assert_eq!(flow_box.flow_children().len(), 0);
+    assert_eq!(flow_box.iter_children().next(), None);
 }
 
 #[gtk::test]
@@ -125,10 +122,11 @@ fn grid_ext() {
 
     widgets.assert_parent();
 
-    let children = grid.children();
-    assert_eq!(children.get(0), Some(widgets.0.as_ref()));
-    assert_eq!(children.get(1), Some(widgets.1.as_ref()));
-    assert_eq!(children.get(2), Some(widgets.2.as_ref()));
+    let mut children = grid.iter_children();
+    assert!(same_widgets(children.next(), Some(&widgets.0)));
+    assert!(same_widgets(children.next(), Some(&widgets.1)));
+    assert!(same_widgets(children.next(), Some(&widgets.2)));
+    assert_eq!(children.next(), None);
 
     grid.remove_all();
 

--- a/src/extensions/tests.rs
+++ b/src/extensions/tests.rs
@@ -106,8 +106,8 @@ fn flow_box_extension_traits() {
     assert!(same_widgets(flow_children.next(), widgets.0.parent()));
     assert!(same_widgets(flow_children.next(), widgets.1.parent()));
     assert!(same_widgets(flow_children.next(), widgets.2.parent()));
-    assert_eq!(flow_children.next(), None);
     assert_eq!(flow_children.next_back(), None);
+    assert_eq!(flow_children.next(), None);
 
     flow_box.remove_all();
 


### PR DESCRIPTION
1) Remove `RelmRemovableExt::remove_all`. It relies on widget internal structure and may break between releases, which would be hard to maintain.
2) Remove `RelmWidgetExt::iter_children`, `RelmWidgetExt::iter_children_reverse` and `RelmWidgetExt::for_each_children`. Those aren't really reliable and can yeild surprising results on some widgets, like `gtk::HeaderBar` (see [link](https://github.com/AaronErhardt/Relm4/issues/103#issuecomment-1029534362)).
3) Instead, introduce widget-specific extensions: `RelmBoxExt`, `RelmListBoxExt`, `RelmFlowBoxExt` and `RelmGridExt`. Add tests for those extensions.

GTK4 encourages widget-specific implementations, instead of generalizations. See [link](https://discourse.gnome.org/t/gtk4-widget-container-api-model/7672).