### PR TITLE
Fix warning for `inline_css`, adjust API

### DIFF
--- a/relm4-components/src/open_button/factory.rs
+++ b/relm4-components/src/open_button/factory.rs
@@ -35,7 +35,7 @@ impl FactoryPrototype for FileListItem {
         );
         let row = gtk::ListBoxRow::builder().child(&label).build();
 
-        label.inline_css(b"margin: 0;");
+        label.inline_css(b"margin: 0");
 
         let key = key.clone();
         label.connect_clicked(move |_| {

--- a/src/util/widget_plus.rs
+++ b/src/util/widget_plus.rs
@@ -18,9 +18,9 @@ pub trait WidgetPlus {
     /// # use relm4::WidgetPlus;
     /// # gtk::init().unwrap();
     /// # let widget = gtk::Button::new();
-    /// widget.inline_css(b"border: 1px solid red");
+    /// widget.inline_css("border: 1px solid red");
     /// ```
-    fn inline_css(&self, style_data: &[u8]);
+    fn inline_css(&self, style: &str);
 
     /// Try to remove a widget from a widget.
     ///
@@ -45,10 +45,17 @@ impl<W: IsA<Widget> + WidgetExt> WidgetPlus for W {
         }
     }
 
-    fn inline_css(&self, style_data: &[u8]) {
+    fn inline_css(&self, style: &str) {
         let context = self.style_context();
         let provider = gtk::CssProvider::new();
-        provider.load_from_data(&[b"*{", style_data, b"}"].concat());
+
+        let data = if style.ends_with(';') {
+            [b"*{", style.as_bytes(), b"}"].concat()
+        } else {
+            [b"*{", style.as_bytes(), b";}"].concat()
+        };
+
+        provider.load_from_data(&data);
         context.add_provider(&provider, gtk::STYLE_PROVIDER_PRIORITY_APPLICATION + 1);
     }
 


### PR DESCRIPTION
Fix warning that occurs when you use `inline_css` without `;` at the end:

```rust
(process:108104): Gtk-WARNING **: 13:41:29.363: Theme parsing error: <data>:1:3-13: Expected ';' at end of block
```

A small API change - the method now requires `&str` instead of `&[u8]`.