### PR TITLE
Rename `RelmRemovableExt` to `RelmRemoveExt`

### DIFF
--- a/relm4/src/extensions/mod.rs
+++ b/relm4/src/extensions/mod.rs
@@ -1,5 +1,5 @@
 mod container;
-mod removable;
+mod remove;
 mod set_child;
 
 #[cfg(test)]
@@ -8,7 +8,7 @@ mod tests;
 #[allow(unreachable_pub)]
 pub use self::container::RelmContainerExt;
 #[allow(unreachable_pub)]
-pub use self::removable::{RelmRemovableExt, RelmRemoveAllExt};
+pub use self::remove::{RelmRemoveAllExt, RelmRemoveExt};
 #[allow(unreachable_pub)]
 pub use self::set_child::RelmSetChildExt;
 
@@ -188,7 +188,7 @@ impl<T: RelmIterChildrenExt> DoubleEndedIterator for ChildrenIterator<T> {
 }
 
 /// Widget types which allow iteration over their children.
-pub trait RelmIterChildrenExt: RelmRemovableExt + IsA<gtk::Widget> {
+pub trait RelmIterChildrenExt: RelmRemoveExt + IsA<gtk::Widget> {
     /// Returns an iterator over container children.
     fn iter_children(&self) -> ChildrenIterator<Self> {
         ChildrenIterator::new(self)

--- a/relm4/src/extensions/remove.rs
+++ b/relm4/src/extensions/remove.rs
@@ -2,7 +2,7 @@ use crate::RelmSetChildExt;
 use gtk::prelude::*;
 
 /// Widget types which can have widgets removed from them.
-pub trait RelmRemovableExt {
+pub trait RelmRemoveExt {
     /// Type of container children.
     type Child: IsA<gtk::Widget>;
     /// Removes the widget from the container
@@ -10,14 +10,14 @@ pub trait RelmRemovableExt {
     fn container_remove(&self, widget: &impl AsRef<Self::Child>);
 }
 
-impl<T: RelmSetChildExt> RelmRemovableExt for T {
+impl<T: RelmSetChildExt> RelmRemoveExt for T {
     type Child = gtk::Widget;
     fn container_remove(&self, _widget: &impl AsRef<Self::Child>) {
         self.container_set_child(None::<&gtk::Widget>);
     }
 }
 
-impl RelmRemovableExt for gtk::ListBox {
+impl RelmRemoveExt for gtk::ListBox {
     type Child = gtk::ListBoxRow;
     fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
         let row = widget.as_ref();
@@ -26,7 +26,7 @@ impl RelmRemovableExt for gtk::ListBox {
     }
 }
 
-impl RelmRemovableExt for gtk::FlowBox {
+impl RelmRemoveExt for gtk::FlowBox {
     type Child = gtk::FlowBoxChild;
     fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
         self.remove(widget.as_ref());
@@ -36,7 +36,7 @@ impl RelmRemovableExt for gtk::FlowBox {
 macro_rules! remove_impl {
     ($($type:ty),+) => {
         $(
-            impl RelmRemovableExt for $type {
+            impl RelmRemoveExt for $type {
                 type Child = gtk::Widget;
                 fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
                     self.remove(widget.as_ref());
@@ -49,7 +49,7 @@ macro_rules! remove_impl {
 macro_rules! remove_child_impl {
     ($($type:ty),+) => {
         $(
-            impl RelmRemovableExt for $type {
+            impl RelmRemoveExt for $type {
                 type Child = gtk::Widget;
                 fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
                     self.remove_child(widget.as_ref());


### PR DESCRIPTION
A small fix to make the trait name more intuitive.