### PR TITLE
Builder

### DIFF
--- a/examples/factory.rs
+++ b/examples/factory.rs
@@ -218,7 +218,7 @@ impl SimpleComponent for AppModel {
     }
 
     // Initialize the UI.
-    fn init_parts(
+    fn init(
         counter: Self::InitParams,
         root: &Self::Root,
         input: &Sender<Self::Input>,

--- a/examples/grid_factory.rs
+++ b/examples/grid_factory.rs
@@ -232,7 +232,7 @@ impl SimpleComponent for AppModel {
     }
 
     // Initialize the UI.
-    fn init_parts(
+    fn init(
         counter: Self::InitParams,
         root: &Self::Root,
         input: &Sender<Self::Input>,

--- a/examples/libadwaita/tab_factory.rs
+++ b/examples/libadwaita/tab_factory.rs
@@ -224,7 +224,7 @@ impl SimpleComponent for AppModel {
     }
 
     // Initialize the UI.
-    fn init_parts(
+    fn init(
         counter: Self::InitParams,
         root: &Self::Root,
         input: &Sender<Self::Input>,

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -68,7 +68,7 @@ impl Component for App {
         gtk::Window::default()
     }
 
-    fn init_parts(
+    fn init(
         _args: Self::InitParams,
         root: &Self::Root,
         input: &Sender<Self::Input>,

--- a/examples/settings_list.rs
+++ b/examples/settings_list.rs
@@ -119,7 +119,7 @@ impl Component for App {
             .build()
     }
 
-    fn init_parts(
+    fn init(
         title: Self::InitParams,
         root: &Self::Root,
         _input: &Sender<Self::Input>,

--- a/examples/settings_list.rs
+++ b/examples/settings_list.rs
@@ -21,7 +21,7 @@ fn main() {
         .application_id("org.relm4.SettingsListExample")
         .launch(|_app, window| {
             // Intiialize a component's root widget
-            let component = App::init()
+            let component = App::builder()
                 // Attach the root widget to the given window.
                 .attach_to(&window)
                 // Start the component service with an initial parameter

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -55,7 +55,7 @@ impl SimpleComponent for AppModel {
     }
 
     // Initialize the UI.
-    fn init_parts(
+    fn init(
         counter: Self::InitParams,
         root: &Self::Root,
         input: &Sender<Self::Input>,

--- a/examples/simple_manual.rs
+++ b/examples/simple_manual.rs
@@ -37,7 +37,7 @@ impl SimpleComponent for AppModel {
     }
 
     /// Initialize the UI.
-    fn init_parts(
+    fn init(
         counter: Self::InitParams,
         window: &Self::Root,
         input: &Sender<Self::Input>,

--- a/relm4-macros/src/component/funcs.rs
+++ b/relm4-macros/src/component/funcs.rs
@@ -4,7 +4,7 @@ use syn::{spanned::Spanned, Error, ImplItemMethod, Result};
 
 pub(super) struct Funcs {
     pub unhandled_fns: Vec<ImplItemMethod>,
-    pub init_parts: ImplItemMethod,
+    pub init: ImplItemMethod,
     pub pre_view: Option<TokenStream2>,
     pub post_view: Option<TokenStream2>,
 }
@@ -23,7 +23,7 @@ macro_rules! parse_func {
 
 impl Funcs {
     pub fn new(mut funcs: Vec<ImplItemMethod>) -> Result<Self> {
-        let mut init_parts = None;
+        let mut init = None;
         let mut unhandled_fns = Vec::new();
         let mut pre_view = None;
         let mut post_view = None;
@@ -31,14 +31,14 @@ impl Funcs {
         for func in funcs.drain(..) {
             let ident = &func.sig.ident;
 
-            if ident == "init_parts" {
-                if init_parts.is_some() {
+            if ident == "init" {
+                if init.is_some() {
                     return Err(Error::new(
                         func.span().unwrap().into(),
-                        "`init_parts` method defined multiple times",
+                        "`init` method defined multiple times",
                     ));
                 } else {
-                    init_parts = Some(func);
+                    init = Some(func);
                 }
             } else if ident == "pre_view" {
                 let stmts = &func.block.stmts;
@@ -53,11 +53,11 @@ impl Funcs {
             }
         }
 
-        let init_parts = init_parts
-            .ok_or_else(|| Error::new(Span2::call_site(), "`init_parts` method isn't defined"))?;
+        let init =
+            init.ok_or_else(|| Error::new(Span2::call_site(), "`init` method isn't defined"))?;
 
         Ok(Funcs {
-            init_parts,
+            init,
             pre_view,
             post_view,
             unhandled_fns,

--- a/relm4-macros/src/component/mod.rs
+++ b/relm4-macros/src/component/mod.rs
@@ -55,7 +55,7 @@ pub(crate) fn generate_tokens(
     let menus_stream = menus.map(|m| m.menus_stream(&relm4_path));
 
     let funcs::Funcs {
-        init_parts,
+        init,
         pre_view,
         post_view,
         unhandled_fns,
@@ -115,7 +115,7 @@ pub(crate) fn generate_tokens(
         }
     };
 
-    let init_parts_injected = match inject_view_code(init_parts, view_code, widgets_return_code) {
+    let init_injected = match inject_view_code(init, view_code, widgets_return_code) {
         Ok(method) => method,
         Err(err) => return err.to_compile_error(),
     };
@@ -140,7 +140,7 @@ pub(crate) fn generate_tokens(
                 #init_root
             }
 
-            #init_parts_injected
+            #init_injected
 
             /// Update the view to represent the updated model.
             fn update_view(

--- a/relm4/src/app.rs
+++ b/relm4/src/app.rs
@@ -24,7 +24,7 @@ where
 
         let app = gtk::Application::builder().application_id(app_id).build();
 
-        let bridge = C::init();
+        let bridge = ComponentBuilder::<C>::new();
 
         Self { bridge, app }
     }

--- a/relm4/src/component/builder.rs
+++ b/relm4/src/component/builder.rs
@@ -22,6 +22,15 @@ pub struct ComponentBuilder<C: Component> {
 }
 
 impl<C: Component> ComponentBuilder<C> {
+    #[allow(clippy::new_without_default)]
+    /// Prepares a component for initialization.
+    pub fn new() -> Self {
+        ComponentBuilder {
+            root: C::init_root(),
+            component: PhantomData,
+        }
+    }
+
     /// Configure the root widget before launching.
     pub fn update_root<F: FnOnce(&mut C::Root)>(mut self, func: F) -> Self {
         func(&mut self.root);

--- a/relm4/src/component/builder.rs
+++ b/relm4/src/component/builder.rs
@@ -86,7 +86,7 @@ impl<C: Component> ComponentBuilder<C> {
 
         // Constructs the initial model and view with the initial payload.
         let watcher = Rc::new(StateWatcher {
-            state: RefCell::new(C::init_parts(payload, &root, &input_tx, &output_tx)),
+            state: RefCell::new(C::init(payload, &root, &input_tx, &output_tx)),
             notifier,
         });
 

--- a/relm4/src/component/traits.rs
+++ b/relm4/src/component/traits.rs
@@ -4,7 +4,6 @@
 
 use super::*;
 use crate::{shutdown::ShutdownReceiver, Sender};
-use std::marker::PhantomData;
 
 /// Elm-style variant of a Component with view updates separated from input updates
 pub trait Component: Sized + 'static {
@@ -38,7 +37,7 @@ pub trait Component: Sized + 'static {
     fn init_root() -> Self::Root;
 
     /// Creates the initial model and view, docking it into the component.
-    fn init_parts(
+    fn init(
         params: Self::InitParams,
         root: &Self::Root,
         input: &Sender<Self::Input>,
@@ -137,7 +136,7 @@ pub trait SimpleComponent: Sized + 'static {
     fn init_root() -> Self::Root;
 
     /// Creates the initial model and view, docking it into the component.
-    fn init_parts(
+    fn init(
         params: Self::InitParams,
         root: &Self::Root,
         input: &Sender<Self::Input>,
@@ -190,13 +189,13 @@ where
         C::init_root()
     }
 
-    fn init_parts(
+    fn init(
         params: Self::InitParams,
         root: &Self::Root,
         input: &Sender<Self::Input>,
         output: &Sender<Self::Output>,
     ) -> ComponentParts<Self> {
-        C::init_parts(params, root, input, output)
+        C::init(params, root, input, output)
     }
 
     fn update(

--- a/relm4/src/component/traits.rs
+++ b/relm4/src/component/traits.rs
@@ -29,16 +29,13 @@ pub trait Component: Sized + 'static {
     /// The type that's used for storing widgets created for this component.
     type Widgets: 'static;
 
+    /// Create a builder for this component.
+    fn builder() -> ComponentBuilder<Self> {
+        ComponentBuilder::<Self>::new()
+    }
+
     /// Initializes the root widget
     fn init_root() -> Self::Root;
-
-    /// Initializes the root widget and prepares a `Bridge` for docking.
-    fn init() -> ComponentBuilder<Self> {
-        ComponentBuilder {
-            root: Self::init_root(),
-            component: PhantomData,
-        }
-    }
 
     /// Creates the initial model and view, docking it into the component.
     fn init_parts(
@@ -138,14 +135,6 @@ pub trait SimpleComponent: Sized + 'static {
 
     /// Initializes the root widget
     fn init_root() -> Self::Root;
-
-    /// Initializes the root widget and prepares a `Bridge` for docking.
-    fn init() -> ComponentBuilder<Self> {
-        ComponentBuilder {
-            root: Self::init_root(),
-            component: PhantomData,
-        }
-    }
 
     /// Creates the initial model and view, docking it into the component.
     fn init_parts(

--- a/relm4/src/factory/mod.rs
+++ b/relm4/src/factory/mod.rs
@@ -161,7 +161,6 @@ where
             .iter_mut()
             .for_each(|s| s.changed = false);
 
-
         // Set rendered state to the state of the model
         // because everything should be up-to-date now.
         drop(rendered_state);
@@ -479,8 +478,16 @@ where
         for (index, hash) in hashes.iter().enumerate() {
             let rendered_state = self.rendered_state.get_mut();
 
-            if *hash != rendered_state.get(index).map(|state| state.widget_hash).unwrap_or_default() {
-                let old_position = rendered_state.iter().position(|state| state.widget_hash == *hash).expect("A new widget was added");
+            if *hash
+                != rendered_state
+                    .get(index)
+                    .map(|state| state.widget_hash)
+                    .unwrap_or_default()
+            {
+                let old_position = rendered_state
+                    .iter()
+                    .position(|state| state.widget_hash == *hash)
+                    .expect("A new widget was added");
 
                 let elem = rendered_state.remove(old_position).unwrap();
                 rendered_state.insert(index, elem);


### PR DESCRIPTION
- Adds `ComponentBuilder::<C>::new()` as an alternative to `Component::init`
- Replaces `Component::init` with `Component::builder`
- Renames `Component::init_parts` with `Component::init`

Closes #140 