### PR TITLE
Add `SimpleComponent::builder`

### DIFF
--- a/relm4/src/component/traits.rs
+++ b/relm4/src/component/traits.rs
@@ -132,6 +132,11 @@ pub trait SimpleComponent: Sized + 'static {
     /// The type that's used for storing widgets created for this component.
     type Widgets: 'static;
 
+    /// Create a builder for this component.
+    fn builder() -> ComponentBuilder<Self> {
+        ComponentBuilder::<Self>::new()
+    }
+
     /// Initializes the root widget
     fn init_root() -> Self::Root;
 


### PR DESCRIPTION
Add `builder` to `SimpleComponent` so you don't have to import `Component` in the scope.