### PR TITLE
refactor!: Combine senders into ComponentSender type

### DIFF
--- a/examples/factory.rs
+++ b/examples/factory.rs
@@ -1,7 +1,7 @@
 use gtk::prelude::{BoxExt, ButtonExt, GtkWindowExt, OrientableExt};
 use relm4::{
     factory::{DynamicIndex, FactoryComponent, FactoryVecDeque},
-    gtk, send, ComponentParts, RelmApp, Sender, SimpleComponent, WidgetPlus,
+    gtk, ComponentParts, ComponentSender, RelmApp, Sender, SimpleComponent, WidgetPlus,
 };
 
 #[derive(Debug)]
@@ -197,15 +197,15 @@ impl SimpleComponent for AppModel {
 
                 gtk::Button {
                     set_label: "Add counter",
-                    connect_clicked(input) => move |_| {
-                        send!(input, AppMsg::AddCounter);
+                    connect_clicked(sender) => move |_| {
+                        sender.input(AppMsg::AddCounter);
                     }
                 },
 
                 gtk::Button {
                     set_label: "Remove counter",
-                    connect_clicked(input) => move |_| {
-                        send!(input, AppMsg::RemoveCounter);
+                    connect_clicked(sender) => move |_| {
+                        sender.input(AppMsg::RemoveCounter);
                     }
                 },
 
@@ -221,26 +221,20 @@ impl SimpleComponent for AppModel {
     fn init(
         counter: Self::InitParams,
         root: &Self::Root,
-        input: &Sender<Self::Input>,
-        _output: &Sender<Self::Output>,
+        sender: &ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         // Insert the macro codegen here
         let widgets = view_output!();
 
         let model = AppModel {
             created_widgets: counter,
-            counters: FactoryVecDeque::new(widgets.counter_box.clone(), input),
+            counters: FactoryVecDeque::new(widgets.counter_box.clone(), &sender.input),
         };
 
         ComponentParts { model, widgets }
     }
 
-    fn update(
-        &mut self,
-        msg: Self::Input,
-        _input: &Sender<Self::Input>,
-        _ouput: &Sender<Self::Output>,
-    ) {
+    fn update(&mut self, msg: Self::Input, _sender: &ComponentSender<Self>) {
         match msg {
             AppMsg::AddCounter => {
                 self.counters.push_back(self.created_widgets);

--- a/examples/grid_factory.rs
+++ b/examples/grid_factory.rs
@@ -1,7 +1,7 @@
 use gtk::prelude::{BoxExt, ButtonExt, GridExt, GtkWindowExt, OrientableExt};
 use relm4::{
     factory::{positions::GridPosition, DynamicIndex, FactoryComponent, FactoryVecDeque, Position},
-    gtk, send, ComponentParts, RelmApp, Sender, SimpleComponent, WidgetPlus,
+    gtk, ComponentParts, ComponentSender, RelmApp, Sender, SimpleComponent, WidgetPlus,
 };
 
 #[derive(Debug)]
@@ -210,15 +210,15 @@ impl SimpleComponent for AppModel {
 
                 gtk::Button {
                     set_label: "Add counter",
-                    connect_clicked(input) => move |_| {
-                        send!(input, AppMsg::AddCounter);
+                    connect_clicked(sender) => move |_| {
+                        sender.input(AppMsg::AddCounter);
                     }
                 },
 
                 gtk::Button {
                     set_label: "Remove counter",
-                    connect_clicked(input) => move |_| {
-                        send!(input, AppMsg::RemoveCounter);
+                    connect_clicked(sender) => move |_| {
+                        sender.input(AppMsg::RemoveCounter);
                     }
                 },
 
@@ -235,26 +235,20 @@ impl SimpleComponent for AppModel {
     fn init(
         counter: Self::InitParams,
         root: &Self::Root,
-        input: &Sender<Self::Input>,
-        _output: &Sender<Self::Output>,
+        sender: &ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         // Insert the macro codegen here
         let widgets = view_output!();
 
         let model = AppModel {
             created_widgets: counter,
-            counters: FactoryVecDeque::new(widgets.counter_box.clone(), input),
+            counters: FactoryVecDeque::new(widgets.counter_box.clone(), &sender.input),
         };
 
         ComponentParts { model, widgets }
     }
 
-    fn update(
-        &mut self,
-        msg: Self::Input,
-        _input: &Sender<Self::Input>,
-        _ouput: &Sender<Self::Output>,
-    ) {
+    fn update(&mut self, msg: Self::Input, _sender: &ComponentSender<Self>) {
         match msg {
             AppMsg::AddCounter => {
                 self.counters.push_back(self.created_widgets);

--- a/examples/libadwaita/tab_factory.rs
+++ b/examples/libadwaita/tab_factory.rs
@@ -2,7 +2,7 @@ use gtk::prelude::{BoxExt, ButtonExt, GtkWindowExt, OrientableExt};
 use relm4::{
     adw,
     factory::{DynamicIndex, FactoryComponent, FactoryVecDeque},
-    gtk, send, ComponentParts, RelmApp, Sender, SimpleComponent,
+    gtk, ComponentParts, ComponentSender, RelmApp, Sender, SimpleComponent,
 };
 
 #[derive(Debug)]
@@ -206,15 +206,15 @@ impl SimpleComponent for AppModel {
 
                 gtk::Button {
                     set_label: "Add counter",
-                    connect_clicked(input) => move |_| {
-                        send!(input, AppMsg::AddCounter);
+                    connect_clicked(sender) => move |_| {
+                        sender.input(AppMsg::AddCounter);
                     }
                 },
 
                 gtk::Button {
                     set_label: "Remove counter",
-                    connect_clicked(input) => move |_| {
-                        send!(input, AppMsg::RemoveCounter);
+                    connect_clicked(sender) => move |_| {
+                        sender.input(AppMsg::RemoveCounter);
                     }
                 },
 
@@ -227,26 +227,20 @@ impl SimpleComponent for AppModel {
     fn init(
         counter: Self::InitParams,
         root: &Self::Root,
-        input: &Sender<Self::Input>,
-        _output: &Sender<Self::Output>,
+        sender: &ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         // Insert the macro codegen here
         let widgets = view_output!();
 
         let model = AppModel {
             created_widgets: counter,
-            counters: FactoryVecDeque::new(widgets.tabs.clone(), input),
+            counters: FactoryVecDeque::new(widgets.tabs.clone(), &sender.input),
         };
 
         ComponentParts { model, widgets }
     }
 
-    fn update(
-        &mut self,
-        msg: Self::Input,
-        _input: &Sender<Self::Input>,
-        _ouput: &Sender<Self::Output>,
-    ) {
+    fn update(&mut self, msg: Self::Input, _sender: &ComponentSender<Self>) {
         self.counters.apply_external_updates();
         match msg {
             AppMsg::AddCounter => {

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -71,8 +71,7 @@ impl Component for App {
     fn init(
         _args: Self::InitParams,
         root: &Self::Root,
-        input: &Sender<Self::Input>,
-        _output: &Sender<Self::Output>,
+        sender: &ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         relm4::view! {
             container = gtk::Box {
@@ -104,8 +103,8 @@ impl Component for App {
 
                 append: button = &gtk::Button {
                     set_label: "Compute",
-                    connect_clicked(input) => move |_| {
-                        input.send(Input::Compute);
+                    connect_clicked(sender) => move |_| {
+                        sender.input(Input::Compute);
                     }
                 }
             }
@@ -126,23 +125,17 @@ impl Component for App {
     fn update(
         &mut self,
         message: Self::Input,
-        _input: &Sender<Self::Input>,
-        _output: &Sender<Self::Output>,
+        _sender: &ComponentSender<Self>,
     ) -> Option<Self::Command> {
         match message {
             Input::Compute => {
                 self.computing = true;
-                return Some(Command::Compute);
+                Some(Command::Compute)
             }
         }
     }
 
-    fn update_cmd(
-        &mut self,
-        message: Self::CommandOutput,
-        _input: &Sender<Self::Input>,
-        _output: &Sender<Self::Output>,
-    ) {
+    fn update_cmd(&mut self, message: Self::CommandOutput, _sender: &ComponentSender<Self>) {
         if let CmdOut::Finished(_) = message {
             self.computing = false;
         }
@@ -150,12 +143,7 @@ impl Component for App {
         self.task = Some(message);
     }
 
-    fn update_view(
-        &self,
-        widgets: &mut Self::Widgets,
-        _input: &Sender<Self::Input>,
-        _output: &Sender<Self::Output>,
-    ) {
+    fn update_view(&self, widgets: &mut Self::Widgets, _sender: &ComponentSender<Self>) {
         widgets.button.set_sensitive(!self.computing);
 
         if let Some(ref progress) = self.task {

--- a/examples/settings_list.rs
+++ b/examples/settings_list.rs
@@ -122,11 +122,10 @@ impl Component for App {
     fn init(
         title: Self::InitParams,
         root: &Self::Root,
-        _input: &Sender<Self::Input>,
-        output: &Sender<Self::Output>,
+        sender: &ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         // Request the caller to reload its options.
-        output.send(Output::Reload);
+        sender.output(Output::Reload);
 
         let label = gtk::builders::LabelBuilder::new()
             .label(&title)
@@ -156,8 +155,7 @@ impl Component for App {
     fn update(
         &mut self,
         message: Self::Input,
-        _input: &Sender<Self::Input>,
-        output: &Sender<Self::Output>,
+        sender: &ComponentSender<Self>,
     ) -> Option<Self::Command> {
         match message {
             Input::AddSetting {
@@ -174,32 +172,22 @@ impl Component for App {
             }
 
             Input::Reload => {
-                output.send(Output::Reload);
+                sender.output(Output::Reload);
             }
         }
 
         None
     }
 
-    fn update_cmd(
-        &mut self,
-        message: Self::CommandOutput,
-        _input: &Sender<Self::Input>,
-        output: &Sender<Self::Output>,
-    ) {
+    fn update_cmd(&mut self, message: Self::CommandOutput, sender: &ComponentSender<Self>) {
         match message {
             CmdOut::Reload => {
-                output.send(Output::Reload);
+                sender.output(Output::Reload);
             }
         }
     }
 
-    fn update_view(
-        &self,
-        widgets: &mut Self::Widgets,
-        _input: &Sender<Self::Input>,
-        output: &Sender<Self::Output>,
-    ) {
+    fn update_view(&self, widgets: &mut Self::Widgets, sender: &ComponentSender<Self>) {
         if self.options.is_empty() && !widgets.options.is_empty() {
             widgets.list.remove_all();
         } else if self.options.len() != widgets.options.len() {
@@ -226,8 +214,8 @@ impl Component for App {
                             set_label: button_label,
                             set_size_group: &widgets.button_sg,
 
-                            connect_clicked(output) => move |_| {
-                                output.send(Output::Clicked(id));
+                            connect_clicked(sender) => move |_| {
+                                sender.output(Output::Clicked(id));
                             }
                         }
                     }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,5 @@
 use gtk::prelude::{BoxExt, ButtonExt, GtkWindowExt, OrientableExt};
-use relm4::{gtk, send, ComponentParts, RelmApp, Sender, SimpleComponent, WidgetPlus};
+use relm4::{gtk, ComponentParts, ComponentSender, RelmApp, SimpleComponent, WidgetPlus};
 
 struct AppModel {
     counter: u8,
@@ -34,15 +34,15 @@ impl SimpleComponent for AppModel {
 
                 gtk::Button {
                     set_label: "Increment",
-                    connect_clicked(input) => move |_| {
-                        send!(input, AppMsg::Increment);
+                    connect_clicked(sender) => move |_| {
+                        sender.input(AppMsg::Increment);
                     }
                 },
 
                 gtk::Button {
                     set_label: "Decrement",
-                    connect_clicked(input) => move |_| {
-                        send!(input, AppMsg::Decrement);
+                    connect_clicked(sender) => move |_| {
+                        sender.input(AppMsg::Decrement);
                     }
                 },
 
@@ -58,8 +58,7 @@ impl SimpleComponent for AppModel {
     fn init(
         counter: Self::InitParams,
         root: &Self::Root,
-        input: &Sender<Self::Input>,
-        _output: &Sender<Self::Output>,
+        sender: &ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         let model = AppModel { counter };
 
@@ -69,12 +68,7 @@ impl SimpleComponent for AppModel {
         ComponentParts { model, widgets }
     }
 
-    fn update(
-        &mut self,
-        msg: Self::Input,
-        _input: &Sender<Self::Input>,
-        _ouput: &Sender<Self::Output>,
-    ) {
+    fn update(&mut self, msg: Self::Input, _sender: &ComponentSender<Self>) {
         match msg {
             AppMsg::Increment => {
                 self.counter = self.counter.wrapping_add(1);

--- a/relm4-macros/src/component/mod.rs
+++ b/relm4-macros/src/component/mod.rs
@@ -146,8 +146,7 @@ pub(crate) fn generate_tokens(
             fn update_view(
                 &self,
                 widgets: &mut Self::Widgets,
-                input: &Sender<Self::Input>,
-                output: &Sender<Self::Output>,
+                sender: &ComponentSender<Self>,
             ) {
                 let Self::Widgets {
                     #return_fields

--- a/relm4/src/component/mod.rs
+++ b/relm4/src/component/mod.rs
@@ -5,6 +5,7 @@
 mod builder;
 mod connector;
 mod controller;
+mod sender;
 mod state_watcher;
 mod traits;
 
@@ -14,6 +15,8 @@ pub use self::builder::ComponentBuilder;
 pub use self::connector::Connector;
 #[allow(unreachable_pub)]
 pub use self::controller::{ComponentController, Controller};
+#[allow(unreachable_pub)]
+pub use self::sender::{ComponentSender, ComponentSenderInner};
 #[allow(unreachable_pub)]
 pub use self::state_watcher::StateWatcher;
 #[allow(unreachable_pub)]

--- a/relm4/src/component/sender.rs
+++ b/relm4/src/component/sender.rs
@@ -1,0 +1,40 @@
+// Copyright 2022 System76 <info@system76.com>
+// SPDX-License-Identifier: MIT or Apache-2.0
+
+use crate::{Component, Sender};
+use std::sync::Arc;
+
+/// Contain senders used by the component.
+pub type ComponentSender<C> = Arc<ComponentSenderInner<C>>;
+
+/// Contains senders used by the component.
+#[derive(Debug)]
+pub struct ComponentSenderInner<C: Component> {
+    /// Emits component inputs
+    pub input: Sender<C::Input>,
+
+    /// Emits component outputs
+    pub output: Sender<C::Output>,
+}
+
+impl<C: Component> ComponentSenderInner<C> {
+    /// Emit an input to the component.
+    pub fn input(&self, message: C::Input) {
+        self.input.send(message);
+    }
+
+    /// Equivalent to `&self.input`.
+    pub fn input_sender(&self) -> &Sender<C::Input> {
+        &self.input
+    }
+
+    /// Emit an output to the component.
+    pub fn output(&self, message: C::Output) {
+        self.output.send(message);
+    }
+
+    /// Equivalent to `&self.output`.
+    pub fn output_sender(&self) -> &Sender<C::Output> {
+        &self.output
+    }
+}


### PR DESCRIPTION
This is an experiment to reduce boilerplate. Feedback would be appreciated if this seems like a good idea or not.

This will combine the two `input: Sender<Self::Input>, output: Sender<Self::Output>` parameters into a single `sender: ComponentSender<Self>`. This new sender type contains the two senders and also implements `fn input(&self, message: Self::Input)` and `fn output(&self, message: Self::Output)` for convenience. The `ComponentSender` is a type alias for an `Rc<ComponentSenderInner>` so it is clonable across signal callbacks.

This could also be extended to contain a command sender so that we could combine the `SimpleComponent` and `Component` traits back together.