### PR TITLE
run CI on all branches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This should be ported to the `next` branch as well, so that we can get CI runs on PRs to that branch. (The build is currently broken on that branch, but it will be helpful to see if there's any unintended breakage).